### PR TITLE
dev-libs/libconfig-9999: Add ebuild to overlay

### DIFF
--- a/dev-libs/libconfig/ChangeLog
+++ b/dev-libs/libconfig/ChangeLog
@@ -1,0 +1,7 @@
+# Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
+# $Header: $
+
+  11 Jan 2015; Marius Brehler <marbre@linux.sungazer.de>
+  +libconfig-9999.ebuild:
+  Add ebuild based on libconfig-1.4.9-r1 to the overlay
+  

--- a/dev-libs/libconfig/libconfig-9999.ebuild
+++ b/dev-libs/libconfig/libconfig-9999.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+AUTOTOOLS_AUTORECONF="1"
+inherit eutils autotools-multilib
+
+DESCRIPTION="Libconfig is a simple library for manipulating structured configuration files"
+HOMEPAGE="http://www.hyperrealm.com/libconfig/libconfig.html"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://github.com/hyperrealm/libconfig.git"
+	EGIT_BRANCH="master"
+	inherit git-r3
+	KEYWORDS=""
+else
+	SRC_URI="http://www.hyperrealm.com/${PN}/${P}.tar.gz"
+	KEYWORDS="amd64 ~arm ~mips ppc ppc64 sparc x86 ~x86-linux"
+	PATCHES=( "${FILESDIR}/${P}-out-of-source-build.patch" )
+fi
+
+IUSE="+cxx examples static-libs"
+
+DEPEND="
+	sys-devel/libtool
+	sys-devel/bison"
+
+src_prepare() {
+	sed -i configure.ac -e 's|AM_CONFIG_HEADER|AC_CONFIG_HEADERS|g' || die
+	autotools-multilib_src_prepare
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		$(use_enable cxx)
+		--disable-examples
+	)
+	autotools-utils_src_configure
+}
+
+multilib_src_test() {
+	# It responds to check but that does not work as intended
+	emake test
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	prune_libtool_files
+
+	if use examples; then
+		find examples/ -name "Makefile.*" -delete || die
+		local dir
+		for dir in examples/c examples/c++; do
+			insinto /usr/share/doc/${PF}/${dir}
+			doins ${dir}/*
+		done
+	fi
+}

--- a/dev-libs/libconfig/libconfig-9999.ebuild
+++ b/dev-libs/libconfig/libconfig-9999.ebuild
@@ -13,8 +13,7 @@ HOMEPAGE="http://www.hyperrealm.com/libconfig/libconfig.html"
 LICENSE="LGPL-2.1"
 SLOT="0"
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="https://github.com/hyperrealm/libconfig.git"
-	EGIT_BRANCH="master"
+	EGIT_REPO_URI="https://github.com/hyperrealm/libconfig.git git://github.com/hyperrealm/libconfig.git"
 	inherit git-r3
 	KEYWORDS=""
 else
@@ -27,7 +26,7 @@ IUSE="+cxx examples static-libs"
 
 DEPEND="
 	sys-devel/libtool
-	sys-devel/bison"
+	virtual/yacc"
 
 src_prepare() {
 	sed -i configure.ac -e 's|AM_CONFIG_HEADER|AC_CONFIG_HEADERS|g' || die

--- a/dev-libs/libconfig/metadata.xml
+++ b/dev-libs/libconfig/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+    <herd>sci</herd>
+    <longdescription lang="en">
+        Libconfig is a simple library for processing structured configuration files.
+        Libconfig is very compact — a fraction of the size of the expat XML parser library.
+        This makes it well-suited for memory-constrained systems like handheld devices.
+        The library includes bindings for both the C and C++ languages.
+        It works on POSIX-compliant UNIX systems (GNU/Linux, Mac OS X, Solaris, FreeBSD).
+    </longdescription>
+</pkgmetadata>


### PR DESCRIPTION
The current version of libconfig in the git repository contain some minor fixes. E.g. the gentoo specific patches are not needed any longer.