### PR TITLE
sci-biology/quicktree: Really move to EAPI=5

### DIFF
--- a/sci-biology/quicktree/quicktree-1.1-r1.ebuild
+++ b/sci-biology/quicktree/quicktree-1.1-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=2
+EAPI=5
 
 inherit toolchain-funcs
 


### PR DESCRIPTION
Also the ChangeLog states it was already bumped, is was still EAPI=2.

>  16 Jun 2013; Justin Lecher <jlec@gentoo.org> quicktree-1.1-r1.ebuild,
>  metadata.xml:
>  Bump to EAPI=5 and fix license