### PR TITLE
sci-libs/arrayfire: Pull master branch; Add git url; Remove keywords

### DIFF
--- a/sci-libs/arrayfire/ChangeLog
+++ b/sci-libs/arrayfire/ChangeLog
@@ -1,6 +1,12 @@
-# ChangeLog for sys-cluster/mpe2
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
+
+*arrayfire-0.9999 (12 Jan 2015)
+
+  12 jan 2015; Marius Brehler <marbre@linux.sungazer.de>
+  +arrayfire-0.9999.ebuild:
+  Symlink to arrayfire-9999, pulls the master branch;
+  default HEAD points to devel
 
 *arrayfire-9999 (10 Jan 2015)
 

--- a/sci-libs/arrayfire/arrayfire-0.9999.ebuild
+++ b/sci-libs/arrayfire/arrayfire-0.9999.ebuild
@@ -1,0 +1,1 @@
+arrayfire-9999.ebuild

--- a/sci-libs/arrayfire/arrayfire-9999.ebuild
+++ b/sci-libs/arrayfire/arrayfire-9999.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://www.arrayfire.com/"
 EGIT_REPO_URI="https://github.com/arrayfire/arrayfire.git git://github.com/arrayfire/arrayfire.git"
 EGIT_BRANCH="master"
 SRC_URI="test? ( https://googletest.googlecode.com/files/gtest-${GTEST_PV}.zip )"
-KEYWORDS="~amd64"
+KEYWORDS=""
 
 LICENSE="BSD"
 SLOT="0"

--- a/sci-libs/arrayfire/arrayfire-9999.ebuild
+++ b/sci-libs/arrayfire/arrayfire-9999.ebuild
@@ -11,9 +11,12 @@ GTEST_PV="1.7.0"
 DESCRIPTION="A general purpose GPU library."
 HOMEPAGE="http://www.arrayfire.com/"
 EGIT_REPO_URI="https://github.com/arrayfire/arrayfire.git git://github.com/arrayfire/arrayfire.git"
-EGIT_BRANCH="master"
 SRC_URI="test? ( https://googletest.googlecode.com/files/gtest-${GTEST_PV}.zip )"
 KEYWORDS=""
+if [[ ${PV} == "0.9999" ]] ; then
+	# the remote HEAD points to devel, but we want to pull the master instead
+	EGIT_BRANCH="master"
+fi
 
 LICENSE="BSD"
 SLOT="0"

--- a/sci-libs/arrayfire/arrayfire-9999.ebuild
+++ b/sci-libs/arrayfire/arrayfire-9999.ebuild
@@ -11,6 +11,7 @@ GTEST_PV="1.7.0"
 DESCRIPTION="A general purpose GPU library."
 HOMEPAGE="http://www.arrayfire.com/"
 EGIT_REPO_URI="https://github.com/arrayfire/arrayfire.git"
+EGIT_BRANCH="master"
 SRC_URI="test? ( https://googletest.googlecode.com/files/gtest-${GTEST_PV}.zip )"
 KEYWORDS="~amd64"
 

--- a/sci-libs/arrayfire/arrayfire-9999.ebuild
+++ b/sci-libs/arrayfire/arrayfire-9999.ebuild
@@ -10,7 +10,7 @@ GTEST_PV="1.7.0"
 
 DESCRIPTION="A general purpose GPU library."
 HOMEPAGE="http://www.arrayfire.com/"
-EGIT_REPO_URI="https://github.com/arrayfire/arrayfire.git"
+EGIT_REPO_URI="https://github.com/arrayfire/arrayfire.git git://github.com/arrayfire/arrayfire.git"
 EGIT_BRANCH="master"
 SRC_URI="test? ( https://googletest.googlecode.com/files/gtest-${GTEST_PV}.zip )"
 KEYWORDS="~amd64"


### PR DESCRIPTION
The [default branch](https://github.com/arrayfire/arrayfire/branches) of the arrayfire repository is devel. I doubt it is a good idea to pull this, so setting EGIT_BRANCH to pull the master.

Further, the git url was missing.