### PR TITLE
sci-libs/arrayfire: Fix dobin of bin2cpp

### DIFF
--- a/sci-libs/arrayfire/arrayfire-9999.ebuild
+++ b/sci-libs/arrayfire/arrayfire-9999.ebuild
@@ -82,5 +82,5 @@ src_configure() {
 src_install() {
 	cmake-utils_src_install
 
-	dobin "bin2cpp"
+	dobin "${BUILD_DIR}/bin2cpp"
 }


### PR DESCRIPTION
Unfortunately, I didn't have tested well enough. Installation of bin2cpp executable is now fixed.