### PR TITLE
Fix KEYWORDS in nvidia-cuda-sdk ebuild

### DIFF
--- a/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-7.0.18.ebuild
+++ b/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-7.0.18.ebuild
@@ -1,6 +1,6 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/dev-util/nvidia-cuda-sdk/nvidia-cuda-sdk-6.5.14.ebuild,v 1.8 2014/12/26 18:08:45 jlec Exp $
+# $Header: $
 
 EAPI=5
 
@@ -15,7 +15,7 @@ SRC_URI="cuda_${PV}_rc_linux.run"
 
 LICENSE="CUDPP"
 SLOT="0"
-KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~amd64-linux"
 IUSE="debug +doc +examples opencl +cuda"
 
 RDEPEND="


### PR DESCRIPTION
Fix header and copyright, but much more imported fixed the KEYWORDS. This removes the QA errors.