### PR TITLE
Fix ebuild for librecad 2.0.7

### DIFF
--- a/media-gfx/librecad/librecad-2.0.7.ebuild
+++ b/media-gfx/librecad/librecad-2.0.7.ebuild
@@ -24,6 +24,7 @@ DEPEND="
 	media-libs/freetype"
 
 RDEPEND="${DEPEND}"
+S="${WORKDIR}/LibreCAD-${PV}"
 
 src_prepare() {
 	# currently RS_VECTOR3D causes an internal compiler error on GCC-4.8

--- a/media-gfx/librecad/librecad-2.0.7.ebuild
+++ b/media-gfx/librecad/librecad-2.0.7.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/LibreCAD/LibreCAD/archive/${PV/_/}.zip -> ${P}.zip"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="debug doc tools 3d"
 
 DEPEND="

--- a/media-gfx/librecad/librecad-2.0.7.ebuild
+++ b/media-gfx/librecad/librecad-2.0.7.ebuild
@@ -12,8 +12,8 @@ SRC_URI="https://github.com/LibreCAD/LibreCAD/archive/${PV/_/}.zip -> ${P}.zip"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="debug doc 3d"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug doc tools 3d"
 
 DEPEND="
 	dev-qt/qtgui:4
@@ -33,9 +33,10 @@ src_prepare() {
 
 src_install() {
 	dobin unix/librecad
+	use tools && dobin unix/ttf2lff
 	insinto /usr/share/${PN}
 	doins -r unix/resources/*
 	use doc && dohtml -r support/doc/*
 	doicon librecad/res/main/"${PN}".png
-	make_desktop_entry "${PN}" LibreCAD "${PN}" Graphics
+	make_desktop_entry ${PN} LibreCAD ${PN} Graphics
 }

--- a/media-gfx/librecad/metadata.xml
+++ b/media-gfx/librecad/metadata.xml
@@ -14,5 +14,6 @@
 </longdescription>
   <use>
     <flag name="3d">Use 3D vectors</flag>
+    <flag name="tools">Build additional tool programs</flag>
   </use>
 </pkgmetadata>


### PR DESCRIPTION
- Fix the ${S} variable, build fails with wrong non-existent source directory
- Some improvements, and add tools USE flag present in 2.0.6 from the main portage tree.