### PR TITLE
dev-util/smartgit version bump to 6.5.6

### DIFF
--- a/dev-util/smartgit/smartgit-6.5.6.ebuild
+++ b/dev-util/smartgit/smartgit-6.5.6.ebuild
@@ -7,11 +7,11 @@ EAPI=5
 inherit eutils java-utils-2 versionator
 
 MY_PV="$(replace_all_version_separators _)"
-MY_P="${PN}hg-generic-${MY_PV}"
+MY_P="${PN}-generic-${MY_PV}"
 
 DESCRIPTION="Git client with support for GitHub Pull Requests+Comments, SVN and Mercurial"
 HOMEPAGE="http://www.syntevo.com/smartgit"
-SRC_URI="http://www.syntevo.com/download/${PN}hg/${MY_P}.tar.gz"
+SRC_URI="http://www.syntevo.com/download/${PN}/${MY_P}.tar.gz"
 
 SLOT="0"
 LICENSE="smartgit"
@@ -23,7 +23,7 @@ RESTRICT="fetch"
 RDEPEND=">=virtual/jre-1.7:1.7"
 DEPEND="${RDEPEND}"
 
-S="${WORKDIR}"/${MY_P/-generic/}
+S="${WORKDIR}"/${PN}
 
 pkg_nofetch(){
 	einfo "Please download ${A} from:"
@@ -38,11 +38,11 @@ src_install() {
 
 	java-pkg_regjar "${ED}"/${rdir}/lib/*.jar
 
-	java-pkg_dolauncher ${PN} --java_args "-Dsun.io.useCanonCaches=false -Xmx256M -Xverify:none -Dsmartgit.vm-xmx=256m" --jar bootloader.jar
+	java-pkg_dolauncher ${PN} --java_args "-Dsun.io.useCanonCaches=false -Xmx768m -Xverify:none -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:InitiatingHeapOccupancyPercent=25" --jar bootloader.jar
 
 	for X in 32 64 128; do
 		insinto /usr/share/icons/hicolor/${X}x${X}/apps
-		newins "${S}"/bin/smartgithg-${X}.png ${PN}.png
+		newins "${S}"/bin/smartgit-${X}.png ${PN}.png
 	done
 
 	make_desktop_entry "${PN}" "SmartGIT" ${PN} "Development;RevisionControl"


### PR DESCRIPTION
In the update, they removed some of the `hg` suffixes.

The launcher requires `SWT_GTK3` env var to be set:
```ShellSession
SWT_GTK3=0 smartgit
```