### PR TITLE
sci-libs/calculix-ccx: inherit fortran-2 as well

### DIFF
--- a/sci-libs/calculix-ccx/calculix-ccx-2.8_p2.ebuild
+++ b/sci-libs/calculix-ccx/calculix-ccx-2.8_p2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit eutils toolchain-funcs flag-o-matic
+inherit eutils toolchain-funcs flag-o-matic fortran-2
 
 MY_P=ccx_${PV/_/}
 


### PR DESCRIPTION
thanks to jlec for notice
A missing mistake in addition to #422 