### PR TITLE
dev-python/pyfftw: Implement python_test()

### DIFF
--- a/dev-python/pyfftw/ChangeLog
+++ b/dev-python/pyfftw/ChangeLog
@@ -1,6 +1,9 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  30 May 2015; Marius Brehler <marbre@linux.sungazer.de> pyfftw-9999.ebuild:
+  Implement python_test()
+
 *pyfftw-9999 (04 Feb 2015)
 *pyfftw-0.9.2 (04 Feb 2015)
 

--- a/dev-python/pyfftw/pyfftw-9999.ebuild
+++ b/dev-python/pyfftw/pyfftw-9999.ebuild
@@ -30,11 +30,12 @@ RDEPEND="
 	>=sci-libs/fftw-3.3.3
 	>=dev-python/cython-0.19.1[${PYTHON_USEDEP}]
 	"
-DEPEND="${RDEPEND}
-	test? ( dev-python/pytest[${PYTHON_USEDEP}] )
-	"
+DEPEND="${RDEPEND}"
 
 python_test() {
 	distutils_install_for_testing
+	cd "${TEST_DIR}"/lib || die
+	cp "${S}"/setup.py "${TEST_DIR}"/lib/ || die
+	cp -r "${S}"/test "${TEST_DIR}"/lib/ || die
 	esetup.py test || die
 }

--- a/dev-python/pyfftw/pyfftw-9999.ebuild
+++ b/dev-python/pyfftw/pyfftw-9999.ebuild
@@ -23,10 +23,18 @@ fi
 
 LICENSE="BSD"
 SLOT="0"
+IUSE="test"
 
 RDEPEND="
 	>=dev-python/numpy-1.8.0[${PYTHON_USEDEP}]
 	>=sci-libs/fftw-3.3.3
 	>=dev-python/cython-0.19.1[${PYTHON_USEDEP}]
 	"
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	test? ( dev-python/pytest[${PYTHON_USEDEP}] )
+	"
+
+python_test() {
+	distutils_install_for_testing
+	esetup.py test || die
+}


### PR DESCRIPTION
I tried to implement the python_test() phase for pyfftw, unfortunately all tests fail with

`ImportError: No module named 'pyfftw.pyfftw'`

I tested
```bash
cd "${TEST_DIR}" || die
```
and
```bash
cd "${TEST_DIR}"/lib || die
```
as described in the [wiki](https://wiki.gentoo.org/wiki/Project:Python/distutils-r1#distutils_install_for_testing), but had no luck. Maybe somebody sees my mistake and can help.

In this ebuild, the package is named `pyfftw` while upstream names it `pyFFTW`. Anyway, renaming the ebuilds didn't helped. Thus, this shouldn't be a naming problem.