### PR TITLE
Updated pagmo URIs.

### DIFF
--- a/sci-libs/pagmo/ChangeLog
+++ b/sci-libs/pagmo/ChangeLog
@@ -1,6 +1,9 @@
 # ChangeLog for sci-libs/pagmo
-# Copyright 1999-2014 Gentoo Foundation; Distributed under the GPL v2
+# Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
+
+  22 Jul 2015; Conrado Miranda <miranda.conrado@gmail.org> pagmo-9999.ebuild:
+  sci-libs/pagmo: Updated URIs.
 
   06 Jan 2014; Justin Lecher <jlec@gentoo.org> pagmo-9999.ebuild:
   Add missing python deps

--- a/sci-libs/pagmo/pagmo-9999.ebuild
+++ b/sci-libs/pagmo/pagmo-9999.ebuild
@@ -9,9 +9,9 @@ PYTHON_COMPAT=( python2_7 )
 inherit cmake-utils git-r3 python-single-r1
 
 DESCRIPTION="Parallelization engine for optimization problems"
-HOMEPAGE="http://pagmo.sourceforge.net/"
+HOMEPAGE="https://github.com/esa/pagmo"
 SRC_URI=""
-EGIT_REPO_URI="git://pagmo.git.sourceforge.net/gitroot/pagmo/pagmo"
+EGIT_REPO_URI="https://github.com/esa/pagmo.git"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/sci-libs/pagmo/pagmo-9999.ebuild
+++ b/sci-libs/pagmo/pagmo-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -11,7 +11,7 @@ inherit cmake-utils git-r3 python-single-r1
 DESCRIPTION="Parallelization engine for optimization problems"
 HOMEPAGE="https://github.com/esa/pagmo"
 SRC_URI=""
-EGIT_REPO_URI="https://github.com/esa/pagmo.git"
+EGIT_REPO_URI="https://github.com/esa/${PN}.git git://git@github.com:esa/${PN}.git"
 
 LICENSE="GPL-3"
 SLOT="0"


### PR DESCRIPTION
The PaGMO library moved from sourceforge to GitHub, as described in http://sourceforge.net/projects/pagmo/.