### PR TITLE
Update eslect support for prefix. The current set up was badly broken…

### DIFF
--- a/app-admin/eselect/ChangeLog
+++ b/app-admin/eselect/ChangeLog
@@ -2,6 +2,10 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Header: /var/cvsroot/gentoo-x86/app-admin/eselect/ChangeLog,v 1.179 2011/01/22 21:38:52 ulm Exp $
 
+  22 Jul 2015; François Bissey <francois.bissey@canterbury.ac.nz>
+  files/eselect-1.4.4-alternatives.patch:
+  Restore a couple of needed EROOT
+
 *eselect-1.4.4-r103 (22 Jul 2015)
 
   22 Jul 2015; François Bissey <francois.bissey@canterbury.ac.nz>

--- a/app-admin/eselect/ChangeLog
+++ b/app-admin/eselect/ChangeLog
@@ -2,6 +2,14 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Header: /var/cvsroot/gentoo-x86/app-admin/eselect/ChangeLog,v 1.179 2011/01/22 21:38:52 ulm Exp $
 
+*eselect-1.4.4-r103 (22 Jul 2015)
+
+  22 Jul 2015; François Bissey <francois.bissey@canterbury.ac.nz>
+  +eselect-1.4.4-r103.ebuild, -eselect-1.4.4-r102.ebuild, eselect-9999.ebuild,
+  files/eselect-1.4.4-alternatives.patch:
+  Update eslect support for prefix. The current set up was badly broken with
+  multiple double prefix and other oddities.
+
 *eselect-1.4.4-r102 (06 Jun 2015)
 
   06 Jun 2015; Justin Lecher <jlec@gentoo.org> +eselect-1.4.4-r102.ebuild,

--- a/app-admin/eselect/eselect-1.4.4-r103.ebuild
+++ b/app-admin/eselect/eselect-1.4.4-r103.ebuild
@@ -54,12 +54,6 @@ src_install() {
 		fowners root:portage /var/lib/gentoo/news
 		fperms g+w /var/lib/gentoo/news
 	fi
-
-	# band aid for prefix
-	if use prefix; then
-		cd "${ED}"/usr/share/eselect/libs || die
-		sed -i "s:ALTERNATIVESDIR_ROOTLESS=\"${EPREFIX}:ALTERNATIVESDIR_ROOTLESS=\":" alternatives.bash || die
-	fi
 }
 
 pkg_postinst() {

--- a/app-admin/eselect/eselect-9999.ebuild
+++ b/app-admin/eselect/eselect-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -49,11 +49,7 @@ src_install() {
 
 	# needed by news module
 	keepdir /var/lib/gentoo/news
-	if use prefix; then
-		sed -i \
-			"s:ALTERNATIVESDIR_ROOTLESS=\"${EPREFIX}:ALTERNATIVESDIR_ROOTLESS=\":" \
-			"${ED}"/usr/share/eselect/libs/alternatives-common.bash || die
-	else
+	if ! use prefix; then
 		fowners root:portage /var/lib/gentoo/news
 		fperms g+w /var/lib/gentoo/news
 	fi

--- a/app-admin/eselect/files/eselect-1.4.4-alternatives.patch
+++ b/app-admin/eselect/files/eselect-1.4.4-alternatives.patch
@@ -983,8 +983,8 @@ index 0000000..1b5a2b0
 +
 +	local variables=( PATH LD_LIBRARY_PATH MANPATH )
 +	[[ -n ${!default_*} ]] && local ${!default_*}
-+	local default_LD_LIBRARY_PATH=$(grep '^[^#]' "${ROOT%/}"/etc/ld.so.conf | tr '\n' ':')/lib:/usr/lib
-+	local default_MANPATH=$(MANPATH= man -C"${ROOT%/}"/etc/man.conf -w)
++	local default_LD_LIBRARY_PATH=$(grep '^[^#]' "${EROOT%/}"/etc/ld.so.conf | tr '\n' ':')/lib:/usr/lib
++	local default_MANPATH=$(MANPATH= man -C"${EROOT%/}"/etc/man.conf -w)
 +
 +	local var IFS=:
 +	for var in "${variables[@]}"; do

--- a/app-admin/eselect/files/eselect-1.4.4-alternatives.patch
+++ b/app-admin/eselect/files/eselect-1.4.4-alternatives.patch
@@ -239,7 +239,7 @@ index 0000000..64d74df
 +inherit config output path-manipulation
 +
 +: "${ALTERNATIVESDIR_ROOTLESS:=@sysconfdir@/env.d/alternatives}"
-+ALTERNATIVESDIR="${EROOT%/}${ALTERNATIVESDIR_ROOTLESS}"
++ALTERNATIVESDIR="${ROOT%/}${ALTERNATIVESDIR_ROOTLESS}"
 +
 +get_current_provider() {
 +	local dieprefix="Could not determine current provider for ${ALTERNATIVE}"
@@ -398,22 +398,22 @@ index 0000000..64d74df
 +
 +			if ( LC_ALL=C; [[ ${newsymlinks[new_i]} < ${oldsymlinks[old_i]} ]] ); then
 +				if [[ ${pass} == check ]]; then
-+					if [[ -L ${EROOT%/}${oldsymlinks[old_i]} ]]; then
++					if [[ -L ${ROOT%/}${oldsymlinks[old_i]} ]]; then
 +						:
-+					elif [[ -d ${EROOT%/}${oldsymlinks[old_i]} ]]; then
-+						write_error_msg "Can't remove ${EROOT%/}${oldsymlinks[old_i]}: is a directory${force:+ which is a fatal error that cannot be ignored by --force}"
++					elif [[ -d ${ROOT%/}${oldsymlinks[old_i]} ]]; then
++						write_error_msg "Can't remove ${ROOT%/}${oldsymlinks[old_i]}: is a directory${force:+ which is a fatal error that cannot be ignored by --force}"
 +						errors=yes
-+					elif [[ -e ${EROOT%/}${oldsymlinks[old_i]} ]]; then
++					elif [[ -e ${ROOT%/}${oldsymlinks[old_i]} ]]; then
 +						if [[ -n ${force} ]]; then
-+							write_warning_msg "Removing ${EROOT%/}${oldsymlinks[old_i]} due to --force: is not a symlink"
++							write_warning_msg "Removing ${ROOT%/}${oldsymlinks[old_i]} due to --force: is not a symlink"
 +						else
-+							write_error_msg "Refusing to remove ${EROOT%/}${oldsymlinks[old_i]}: is not a symlink (use --force to override)"
++							write_error_msg "Refusing to remove ${ROOT%/}${oldsymlinks[old_i]}: is not a symlink (use --force to override)"
 +							errors=yes
 +						fi
 +					fi
 +
 +				elif [[ ${pass} == perform ]]; then
-+					rm -f "${EROOT%/}${oldsymlinks[old_i]}" || die "${dieprefix}: rm failed"
++					rm -f "${ROOT%/}${oldsymlinks[old_i]}" || die "${dieprefix}: rm failed"
 +				else
 +					die "${dieprefix}: unknown \${pass} ${pass}???"
 +				fi
@@ -428,23 +428,23 @@ index 0000000..64d74df
 +				done
 +
 +				if [[ ${pass} == check ]]; then
-+					if [[ -L ${EROOT%/}${newsymlinks[new_i]} ]]; then
++					if [[ -L ${ROOT%/}${newsymlinks[new_i]} ]]; then
 +						:
-+					elif [[ -d ${EROOT%/}${newsymlinks[new_i]} ]]; then
-+						write_error_msg "Can't overwrite ${EROOT%/}${newsymlinks[new_i]}: is a directory${force:+ which is a fatal error that cannot be ignored by --force}"
++					elif [[ -d ${ROOT%/}${newsymlinks[new_i]} ]]; then
++						write_error_msg "Can't overwrite ${ROOT%/}${newsymlinks[new_i]}: is a directory${force:+ which is a fatal error that cannot be ignored by --force}"
 +						errors=yes
-+					elif [[ -e ${EROOT%/}${newsymlinks[new_i]} ]]; then
++					elif [[ -e ${ROOT%/}${newsymlinks[new_i]} ]]; then
 +						if [[ -n ${force} ]]; then
-+							write_warning_msg "Overwriting ${EROOT%/}${newsymlinks[new_i]} due to --force: is not a symlink"
++							write_warning_msg "Overwriting ${ROOT%/}${newsymlinks[new_i]} due to --force: is not a symlink"
 +						else
-+							write_error_msg "Refusing to overwrite ${EROOT%/}${newsymlinks[new_i]}: is not a symlink (use --force to override)"
++							write_error_msg "Refusing to overwrite ${ROOT%/}${newsymlinks[new_i]}: is not a symlink (use --force to override)"
 +							errors=yes
 +						fi
 +					fi
 +
 +				elif [[ ${pass} == perform ]]; then
-+					mkdir -p "${EROOT%/}${newsymlinks[new_i]%/*}" || die "${dieprefix}: mkdir -p failed"
-+					ln -snf "${target#/}" "${EROOT%/}${newsymlinks[new_i]}" || die "${dieprefix}: ln -snf failed"
++					mkdir -p "${ROOT%/}${newsymlinks[new_i]%/*}" || die "${dieprefix}: mkdir -p failed"
++					ln -snf "${target#/}" "${ROOT%/}${newsymlinks[new_i]}" || die "${dieprefix}: ln -snf failed"
 +				else
 +					die "${dieprefix}: unknown \${pass} ${pass}???"
 +				fi
@@ -513,7 +513,7 @@ index 0000000..64d74df
 +
 +	# Process source-target pairs
 +	while (( $# >= 2 )); do
-+		src=${1//+(\/)/\/}; target=${2//+(\/)/\/}
++		src="${EROOT%/}"${1//+(\/)/\/}; target=${2//+(\/)/\/}
 +		if [[ ${src} != /* ]]; then
 +			die "Source path must be absolute, but got ${src}"
 +		else
@@ -626,7 +626,7 @@ index 0000000..64d74df
 +		# verify existing provider's symlinks
 +		local p= bad=0
 +		while read -r -d '' p ; do
-+			[[ -L "${EROOT%/}${p}" && -e "${EROOT%/}${p}" ]] || (( bad++ ))
++			[[ -L "${ROOT%/}${p}" && -e "${ROOT%/}${p}" ]] || (( bad++ ))
 +		done < "${ALTERNATIVESDIR}/${ALTERNATIVE}/_current_list"
 +
 +		[[ "${bad}" -eq 0 ]] && return 0
@@ -688,22 +688,22 @@ index 0000000..64d74df
 +		while read -r -d '' symlink; do
 +			one=true
 +			if [[ ${pass} == check ]]; then
-+				if [[ -L ${EROOT%/}${symlink} ]]; then
++				if [[ -L ${ROOT%/}${symlink} ]]; then
 +					:
-+				elif [[ -d ${EROOT%/}${symlink} ]]; then
-+					write_error_msg "Can't remove ${EROOT%/}${symlink}: is a directory${force:+ which is a fatal error that cannot be ignored by --force}"
++				elif [[ -d ${ROOT%/}${symlink} ]]; then
++					write_error_msg "Can't remove ${ROOT%/}${symlink}: is a directory${force:+ which is a fatal error that cannot be ignored by --force}"
 +					errors=yes
-+				elif [[ -e ${EROOT%/}${symlink} ]]; then
++				elif [[ -e ${ROOT%/}${symlink} ]]; then
 +					if [[ -n ${force} ]]; then
-+						write_warning_msg "Removing ${EROOT%/}${symlink} due to --force: is not a symlink"
++						write_warning_msg "Removing ${ROOT%/}${symlink} due to --force: is not a symlink"
 +					else
-+						write_error_msg "Refusing to remove ${EROOT%/}${symlink}: is not a symlink (use --force to override)"
++						write_error_msg "Refusing to remove ${ROOT%/}${symlink}: is not a symlink (use --force to override)"
 +						errors=yes
 +					fi
 +				fi
 +
 +			elif [[ ${pass} == perform ]]; then
-+				rm -f "${EROOT%/}${symlink}" || die "${dieprefix}: rm failed"
++				rm -f "${ROOT%/}${symlink}" || die "${dieprefix}: rm failed"
 +			else
 +				die "${dieprefix}: unknown \${pass} ${pass}???"
 +			fi
@@ -792,7 +792,7 @@ index 0000000..1b5a2b0
 +
 +	local errors symlink rootsymlink
 +	while read -r -d '' symlink; do
-+		rootsymlink="${EROOT%/}${symlink}"
++		rootsymlink="${ROOT%/}${symlink}"
 +		rootsymlink=${rootsymlink//+(\/)/\/}
 +		echo "${rootsymlink}"
 +		if [[ -L ${rootsymlink} ]]; then
@@ -983,8 +983,8 @@ index 0000000..1b5a2b0
 +
 +	local variables=( PATH LD_LIBRARY_PATH MANPATH )
 +	[[ -n ${!default_*} ]] && local ${!default_*}
-+	local default_LD_LIBRARY_PATH=$(grep '^[^#]' "${EROOT%/}"/etc/ld.so.conf | tr '\n' ':')/lib:/usr/lib
-+	local default_MANPATH=$(MANPATH= man -C"${EROOT%/}"/etc/man.conf -w)
++	local default_LD_LIBRARY_PATH=$(grep '^[^#]' "${ROOT%/}"/etc/ld.so.conf | tr '\n' ':')/lib:/usr/lib
++	local default_MANPATH=$(MANPATH= man -C"${ROOT%/}"/etc/man.conf -w)
 +
 +	local var IFS=:
 +	for var in "${variables[@]}"; do


### PR DESCRIPTION
… with multiple double prefix and other oddities.

Package-Manager: portage-2.2.20

This is to solve issue #453, the usage of `EROOT` instead of `ROOT` everywhere place. Introduced `ERROT` in the only place it was making a difference. I am open to the suggestion it should `EPREFIX` instead.