### PR TITLE
Fix Scilab and jlatexmath-fop to build with new versions of dependencies

### DIFF
--- a/dev-java/jlatexmath-fop/ChangeLog
+++ b/dev-java/jlatexmath-fop/ChangeLog
@@ -2,6 +2,9 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  26 Jul 2015; Bryan Gardiner <bog@khumba.net> jlatexmath-fop-1.0.3.ebuild:
+  dev-java/jlatexmath-fop: Fix the dependency on xmlgraphics-commons-2.
+
   22 Jul 2015; Marius Brehler <marbre@linux.sungazer.de>
   jlatexmath-fop-1.0.3.ebuild:
   dev-java/jlatexmath-fop: Fix deps

--- a/dev-java/jlatexmath-fop/jlatexmath-fop-1.0.3.ebuild
+++ b/dev-java/jlatexmath-fop/jlatexmath-fop-1.0.3.ebuild
@@ -33,7 +33,7 @@ src_prepare() {
 	epatch "${FILESDIR}/${P}-fixpaths.patch"
 	cp "${FILESDIR}/version.xml" "${S}" || die
 	echo "fop.jar=$(java-pkg_getjar fop fop.jar)
-xmlgraphics-commons.jar=$(java-pkg_getjar xmlgraphics-commons-2.0 xmlgraphics-commons.jar)
+xmlgraphics-commons.jar=$(java-pkg_getjar xmlgraphics-commons-2 xmlgraphics-commons.jar)
 jlatexmath.jar=$(java-pkg_getjar jlatexmath-1 jlatexmath.jar)" \
 		 >>fop.properties || die
 }

--- a/sci-mathematics/scilab/ChangeLog
+++ b/sci-mathematics/scilab/ChangeLog
@@ -2,6 +2,10 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  29 Jul 2015; Bryan Gardiner <bog@khumba.net> scilab-5.5.2.ebuild:
+  Fix the conditions under which batik is a dependency: it's required for the
+  GUI to do graphic export at runtime as well as to build documentation.
+
   25 Jul 2015; Bryan Gardiner <bog@khumba.net> scilab-5.5.2.ebuild,
   +files/scilab-5.5.2-batik-1.8.patch, +files/scilab-5.5.2-fop-2.0.patch,
   +files/scilab-5.5.2-xmlgraphics-common-2.0.patch:

--- a/sci-mathematics/scilab/ChangeLog
+++ b/sci-mathematics/scilab/ChangeLog
@@ -2,6 +2,11 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  25 Jul 2015; Bryan Gardiner <bog@khumba.net> scilab-5.5.2.ebuild,
+  +files/scilab-5.5.2-batik-1.8.patch, +files/scilab-5.5.2-fop-2.0.patch,
+  +files/scilab-5.5.2-xmlgraphics-common-2.0.patch:
+  Patch Scilab to build with new versions of Java dependencies.
+
   22 Jul 2015; Marius Brehler <marbre@linux.sungazer.de> scilab-5.5.2.ebuild:
   sci-mathematics/scilab: Fix deps
 

--- a/sci-mathematics/scilab/files/scilab-5.5.2-batik-1.8.patch
+++ b/sci-mathematics/scilab/files/scilab-5.5.2-batik-1.8.patch
@@ -1,0 +1,98 @@
+From: Bryan Gardiner <bog@khumba.net>
+Project-Bug-URL: https://bugzilla.scilab.org/show_bug.cgi?id=13813
+Gentoo-Bug-URL: https://github.com/gentoo-science/sci/pull/456
+
+Updates Scilab to build against (and require) Batik >=1.8, fixing an API change
+with SAXSVGDocumentFactory being moved.  This is not tested beyond "yes Scilab
+still links to Batik to export SVGs," as I'm not sure of a good test case, and
+it's awaiting upstream review.
+
+--- a/scilab/configure
++++ b/scilab/configure
+@@ -16600,8 +16600,8 @@ $as_echo "$as_me: WARNING: Could not find or use the Java package/jar batik used
+                 fi
+ 
+ 
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking minimal version (1.7) of batik" >&5
+-$as_echo_n "checking minimal version (1.7) of batik... " >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking minimal version (1.8) of batik" >&5
++$as_echo_n "checking minimal version (1.8) of batik... " >&6; }
+    saved_ac_java_classpath=$ac_java_classpath
+    export ac_java_classpath="$BATIK:$ac_java_classpath"
+    if test "x" == "x"; then
+@@ -16614,7 +16614,7 @@ import org.apache.batik.Version;
+ 
+ public class conftest {
+     public static void main(String[] argv) {
+-        String minVersion="1.7";
++        String minVersion="1.8";
+ 
+                             System.out.println(Version.getVersion());
+                                   if (compare(minVersion, Version.getVersion()) > 0) {
+@@ -16663,7 +16663,7 @@ EOF
+                    STDOUT=`cat conftest.java.output`
+                 fi
+                 echo "configure: CLASSPATH was $CLASSPATH" >&5
+-                  as_fn_error $? "Wrong version of batik. Expected at least 1.7. Found $STDOUT" "$LINENO" 5
++                  as_fn_error $? "Wrong version of batik. Expected at least 1.8. Found $STDOUT" "$LINENO" 5
+                             fi
+         fi
+         if test -f conftest.java.output; then
+@@ -16673,7 +16673,7 @@ EOF
+         echo "configure: failed program was:" >&5
+         cat conftest.java >&5
+         echo "configure: CLASSPATH was $CLASSPATH" >&5
+-          as_fn_error $? "Wrong version of batik. Expected at least 1.7. Found $STDOUT" "$LINENO" 5
++          as_fn_error $? "Wrong version of batik. Expected at least 1.8. Found $STDOUT" "$LINENO" 5
+             fi
+ 
+    else
+@@ -16686,7 +16686,7 @@ import org.apache.batik.Version;
+ 
+ public class conftest {
+     public static void main(String[] argv) {
+-        String minVersion="1.7";
++        String minVersion="1.8";
+ 
+                             System.out.println(Version.getVersion());
+                                   if (compare(minVersion, Version.getVersion()) != 0) {
+@@ -16735,7 +16735,7 @@ EOF
+                    STDOUT=`cat conftest.java.output`
+                 fi
+                 echo "configure: CLASSPATH was $CLASSPATH" >&5
+-                  as_fn_error $? "Wrong version of batik. Expected exact version 1.7. Found $STDOUT" "$LINENO" 5
++                  as_fn_error $? "Wrong version of batik. Expected exact version 1.8. Found $STDOUT" "$LINENO" 5
+                             fi
+         fi
+         if test -f conftest.java.output; then
+@@ -16745,7 +16745,7 @@ EOF
+         echo "configure: failed program was:" >&5
+         cat conftest.java >&5
+         echo "configure: CLASSPATH was $CLASSPATH" >&5
+-          as_fn_error $? "Wrong version of batik. Expected exact version 1.7. Found $STDOUT" "$LINENO" 5
++          as_fn_error $? "Wrong version of batik. Expected exact version 1.8. Found $STDOUT" "$LINENO" 5
+             fi
+ 
+     fi
+--- a/scilab/configure.ac
++++ b/scilab/configure.ac
+@@ -1038,7 +1038,7 @@ interface for JOGL2 - or libGL (OpenGL library) are installed and if the version
+                    BATIK=$PACKAGE_JAR_FILE
+                 fi
+                 AC_SUBST(BATIK)
+-                AC_JAVA_CHECK_VERSION_PACKAGE([batik],[import org.apache.batik.Version;],$BATIK,[1.7],[Version.getVersion()])
++                AC_JAVA_CHECK_VERSION_PACKAGE([batik],[import org.apache.batik.Version;],$BATIK,[1.8],[Version.getVersion()])
+ 
+                 # Commons I/O library
+                 AC_JAVA_CHECK_PACKAGE([commons-io],[org.apache.commons.io.output.CountingOutputStream],[Commons I/O library])
+--- a/scilab/modules/graph/src/java/org/scilab/modules/graph/utils/ScilabGraphUtils.java
++++ b/scilab/modules/graph/src/java/org/scilab/modules/graph/utils/ScilabGraphUtils.java
+@@ -28,7 +28,7 @@ import org.apache.batik.bridge.DocumentLoader;
+ import org.apache.batik.bridge.GVTBuilder;
+ import org.apache.batik.bridge.UserAgent;
+ import org.apache.batik.bridge.UserAgentAdapter;
+-import org.apache.batik.dom.svg.SAXSVGDocumentFactory;
++import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
+ import org.apache.batik.gvt.GraphicsNode;
+ import org.apache.batik.util.XMLResourceDescriptor;
+ import org.scilab.forge.jlatexmath.ParseException;

--- a/sci-mathematics/scilab/files/scilab-5.5.2-fop-2.0.patch
+++ b/sci-mathematics/scilab/files/scilab-5.5.2-fop-2.0.patch
@@ -1,0 +1,38 @@
+From: Bryan Gardiner <bog@khumba.net>
+Project-Bug-URL: https://bugzilla.scilab.org/show_bug.cgi?id=14009
+Gentoo-Bug-URL: https://github.com/gentoo-science/sci/pull/456
+
+Updates Scilab to build against FOP >=2.0.  This is not tested, as I'm not sure
+of a test case, and it's awaiting upstream review.
+
+--- a/scilab/modules/helptools/src/java/org/scilab/modules/helptools/FopConverter.java
++++ b/scilab/modules/helptools/src/java/org/scilab/modules/helptools/FopConverter.java
+@@ -43,10 +43,10 @@ public class FopConverter extends ContainerConverter {
+         String fileName = outputDirectory + "/" + baseName + "." + format.name().toLowerCase();
+ 
+         try {
+-            FopFactory fopFactory = FopFactory.newInstance();
++            FopFactory fopFactory =
++                FopFactory.newInstance(new File(System.getenv("SCI") + "/modules/helptools/etc/fopconf.xml"));
+             fopFactory.addElementMapping(new JLaTeXMathElementMapping());
+             fopFactory.getXMLHandlerRegistry().addXMLHandler(new JLaTeXMathXMLHandler());
+-            fopFactory.setUserConfig(new File(System.getenv("SCI") + "/modules/helptools/etc/fopconf.xml"));
+ 
+             // Step 3: Construct fop with desired output format
+             OutputStream out = new BufferedOutputStream(new FileOutputStream(fileName));
+--- a/scilab/modules/scinotes/src/java/org/scilab/modules/scinotes/utils/CodeExporter.java
++++ b/scilab/modules/scinotes/src/java/org/scilab/modules/scinotes/utils/CodeExporter.java
+@@ -114,11 +114,11 @@ public class CodeExporter extends FOCodeConverter {
+      * @param format the page format
+      */
+     public void convert(String code, int[] lineNumberArray, String fileName, String type, String title, PageFormat format) {
+-        FopFactory fopFactory = FopFactory.newInstance();
+         OutputStream out = null;
+ 
+         try {
+-            fopFactory.setUserConfig(new File(ScilabConstants.SCI + "/modules/helptools/etc/fopconf.xml"));
++            FopFactory fopFactory =
++                FopFactory.newInstance(new File(ScilabConstants.SCI + "/modules/helptools/etc/fopconf.xml"));
+             FOUserAgent userAgent = fopFactory.newFOUserAgent();
+             userAgent.setProducer(CREATOR);
+             userAgent.setTitle(title);

--- a/sci-mathematics/scilab/files/scilab-5.5.2-xmlgraphics-common-2.0.patch
+++ b/sci-mathematics/scilab/files/scilab-5.5.2-xmlgraphics-common-2.0.patch
@@ -1,0 +1,91 @@
+From: Bryan Gardiner <bog@khumba.net>
+Project-Bug-URL: https://bugzilla.scilab.org/show_bug.cgi?id=13724
+Gentoo-Bug-URL: https://github.com/gentoo-science/sci/pull/456
+
+Updates Scilab 5.5.2 to build against xmlgraphics-common >=2.0.  This is not
+tested, as I'm not sure of a test case, and a similar patch (where the
+super.processShape calls are passed cached=true) is already awaiting upstream
+review.
+
+--- a/scilab/modules/graphic_export/src/java/org/scilab/modules/graphic_export/Export.java
++++ b/scilab/modules/graphic_export/src/java/org/scilab/modules/graphic_export/Export.java
+@@ -857,7 +857,7 @@ public class Export {
+                     }
+ 
+                     @Override
+-                    public int processShape(Shape s) throws IOException {
++                    public int processShape(Shape s, boolean cached) throws IOException {
+                         if (s instanceof Ellipse2D.Double) {
+                             Ellipse2D.Double ell = (Ellipse2D.Double) s;
+                             if (ell.height == ell.width) {
+@@ -880,10 +880,10 @@ public class Export {
+                                     buffer.append("[").append(gen.formatDouble(coords[0])).append(" ").append(gen.formatDouble(coords[1]));
+                                     it.next();
+                                 } else {
+-                                    return super.processShape(s);
++                                    return super.processShape(s, cached);
+                                 }
+                             } else {
+-                                return super.processShape(s);
++                                return super.processShape(s, cached);
+                             }
+ 
+                             for (; !it.isDone(); it.next()) {
+@@ -891,7 +891,7 @@ public class Export {
+                                 if (type == PathIterator.SEG_LINETO) {
+                                     buffer.append(" ").append(gen.formatDouble(coords[0])).append(" ").append(gen.formatDouble(coords[1]));
+                                 } else {
+-                                    return super.processShape(s);
++                                    return super.processShape(s, cached);
+                                 }
+                             }
+                             buffer.append("] DP");
+@@ -899,7 +899,7 @@ public class Export {
+                             return PathIterator.WIND_NON_ZERO;
+                         }
+ 
+-                        return super.processShape(s);
++                        return super.processShape(s, cached);
+                     }
+                 };
+                 g2d.setGraphicContext(new GraphicContext());
+@@ -1029,7 +1029,7 @@ public class Export {
+                     }
+ 
+                     @Override
+-                    public int processShape(Shape s) throws IOException {
++                    public int processShape(Shape s, boolean cached) throws IOException {
+                         if (s instanceof Ellipse2D.Double) {
+                             Ellipse2D.Double ell = (Ellipse2D.Double) s;
+                             if (ell.height == ell.width) {
+@@ -1052,10 +1052,10 @@ public class Export {
+                                     buffer.append("[").append(gen.formatDouble(coords[0])).append(" ").append(gen.formatDouble(coords[1]));
+                                     it.next();
+                                 } else {
+-                                    return super.processShape(s);
++                                    return super.processShape(s, cached);
+                                 }
+                             } else {
+-                                return super.processShape(s);
++                                return super.processShape(s, cached);
+                             }
+ 
+                             for (; !it.isDone(); it.next()) {
+@@ -1063,7 +1063,7 @@ public class Export {
+                                 if (type == PathIterator.SEG_LINETO) {
+                                     buffer.append(" ").append(gen.formatDouble(coords[0])).append(" ").append(gen.formatDouble(coords[1]));
+                                 } else {
+-                                    return super.processShape(s);
++                                    return super.processShape(s, cached);
+                                 }
+                             }
+                             buffer.append("] DP");
+@@ -1071,7 +1071,7 @@ public class Export {
+                             return PathIterator.WIND_NON_ZERO;
+                         }
+ 
+-                        return super.processShape(s);
++                        return super.processShape(s, cached);
+                     }
+ 
+                 };

--- a/sci-mathematics/scilab/scilab-5.5.2.ebuild
+++ b/sci-mathematics/scilab/scilab-5.5.2.ebuild
@@ -46,6 +46,7 @@ CDEPEND="dev-libs/libpcre
 	fftw? ( sci-libs/fftw:3.0 )
 	gui? (
 		dev-java/avalon-framework:4.2
+		>=dev-java/batik-1.8-r2:1.8
 		dev-java/commons-io:1
 		dev-java/commons-logging:0
 		>=dev-java/flexdock-1.2.4:0
@@ -75,8 +76,7 @@ DEPEND="${CDEPEND}
 	debug? ( dev-util/lcov )
 	gui? (
 		>=virtual/jdk-1.6
-		doc? ( >=dev-java/batik-1.8-r2:1.8
-			   app-text/docbook-xsl-stylesheets
+		doc? ( app-text/docbook-xsl-stylesheets
 			   dev-java/xml-commons-external:1.4
 			   dev-java/saxon:9 )
 		xcos? ( dev-lang/ocaml )

--- a/sci-mathematics/scilab/scilab-5.5.2.ebuild
+++ b/sci-mathematics/scilab/scilab-5.5.2.ebuild
@@ -49,7 +49,7 @@ CDEPEND="dev-libs/libpcre
 		dev-java/commons-io:1
 		dev-java/commons-logging:0
 		>=dev-java/flexdock-1.2.4:0
-		dev-java/fop:0
+		>=dev-java/fop-2.0:0
 		=dev-java/gluegen-2.2.4:2.2
 		dev-java/javahelp:0
 		dev-java/jeuclid-core:0
@@ -74,8 +74,8 @@ DEPEND="${CDEPEND}
 	virtual/pkgconfig
 	debug? ( dev-util/lcov )
 	gui? (
-		>=virtual/jdk-1.5
-		doc? ( dev-java/batik:1.8
+		>=virtual/jdk-1.6
+		doc? ( >=dev-java/batik-1.8-r2:1.8
 			   app-text/docbook-xsl-stylesheets
 			   dev-java/xml-commons-external:1.4
 			   dev-java/saxon:9 )
@@ -122,9 +122,12 @@ src_prepare() {
 		"${FILESDIR}/${P}-gluegen.patch" \
 		"${FILESDIR}/${P}-fix-random-runtime-failure.patch" \
 		"${FILESDIR}/${P}-accessviolation.patch" \
-		"${FILESDIR}/${P}-missinglib.patch"
+		"${FILESDIR}/${P}-missinglib.patch" \
+		"${FILESDIR}/${P}-batik-1.8.patch" \
+		"${FILESDIR}/${P}-fop-2.0.patch" \
+		"${FILESDIR}/${P}-xmlgraphics-common-2.0.patch"
 
-	# works for me on x86, but users are having                                
+	# works for me on x86, but users are having
 	# trouble without see #282 on github
 	append-ldflags $(no-as-needed)
 
@@ -156,7 +159,7 @@ src_prepare() {
 		java-pkg_jar-from jlatexmath-1,flexdock,skinlf
 		java-pkg_jar-from jgoodies-looks-2.6,jrosetta
 		java-pkg_jar-from avalon-framework-4.2,jeuclid-core
-		java-pkg_jar-from xmlgraphics-commons-1.5,commons-io-1
+		java-pkg_jar-from xmlgraphics-commons-2,commons-io-1
 		java-pkg_jar-from jogl-2.2 jogl-all.jar jogl2.jar
 		java-pkg_jar-from gluegen-2.2 gluegen-rt.jar gluegen2-rt.jar
 		java-pkg_jar-from fop fop.jar
@@ -164,7 +167,7 @@ src_prepare() {
 		java-pkg_jar-from jlatexmath-fop-1
 		use xcos &&	java-pkg_jar-from jgraphx-2.5
 		if use doc; then
-			java-pkg_jar-from --build-only batik-1.7 batik-all.jar
+			java-pkg_jar-from --build-only batik-1.8 batik-all.jar
 			java-pkg_jar-from --build-only saxon-9 saxon.jar saxon9he.jar
 			java-pkg_jar-from --build-only xml-commons-external-1.4 xml-apis-ext.jar
 		fi


### PR DESCRIPTION
Scilab 5.5.2's Java code doesn't compile unmodified against batik-1.8, fop-2.0, and xmlgraphics-common-2.0, so I've written some patches to get it building again.  I'm not familiar with the Scilab internals or the libraries above, but the fixes seemed simple enough.  I'll take care of sending them upstream.

Also dev-java/jlatexmath-fop-1.0.3 specified an incorrect jar dep, preventing it from building.