### PR TITLE
media-gfx/librecad: add a missing dependency with USE="qt5"

### DIFF
--- a/media-gfx/librecad/librecad-2.0.8.ebuild
+++ b/media-gfx/librecad/librecad-2.0.8.ebuild
@@ -27,6 +27,7 @@ DEPEND="
 	            dev-qt/qtcore:5
 	            dev-qt/qtgui:5
 	            dev-qt/qthelp:5
+	            dev-qt/qtprintsupport:5
 	            dev-qt/qtsvg:5
 	            dev-qt/qtwidgets:5
 	            dev-qt/qtxml:5


### PR DESCRIPTION
Hi, this adds a missing dependency on dev-qt/qtprintsupport when building with the qt5 USE flag.