### PR TITLE
sci-mathematics/scilab: Add PaX mark required for Java binaries on hardened.

### DIFF
--- a/sci-mathematics/scilab/ChangeLog
+++ b/sci-mathematics/scilab/ChangeLog
@@ -2,6 +2,12 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Id$
 
+*scilab-5.5.2-r1 (01 Sep 2015)
+
+  01 Sep 2015; Bryan Gardiner <bog@khumba.net> -scilab-5.5.2.ebuild,
+  +scilab-5.5.2-r1.ebuild:
+  Add PaX mark required for Java binaries on hardened.
+
   29 Jul 2015; Bryan Gardiner <bog@khumba.net> scilab-5.5.2.ebuild:
   Fix the conditions under which batik is a dependency: it's required for the
   GUI to do graphic export at runtime as well as to build documentation.

--- a/sci-mathematics/scilab/scilab-5.5.2-r1.ebuild
+++ b/sci-mathematics/scilab/scilab-5.5.2-r1.ebuild
@@ -10,7 +10,7 @@ JAVA_PKG_OPT_USE="gui"
 VIRTUALX_REQUIRED="manual"
 
 inherit eutils autotools bash-completion-r1 check-reqs fdo-mime flag-o-matic \
-	fortran-2 java-pkg-opt-2 toolchain-funcs virtualx
+	fortran-2 java-pkg-opt-2 pax-utils toolchain-funcs virtualx
 
 DESCRIPTION="Scientific software package for numerical computations"
 HOMEPAGE="http://www.scilab.org/"
@@ -230,6 +230,7 @@ src_configure() {
 src_compile() {
 	addpredict /proc/mtrr
 	emake
+	pax-mark m .libs/scilab-bin
 	use doc && emake doc
 }
 


### PR DESCRIPTION
Without the MPROTECT PaX mark, Scilab gets killed during the build when it tries to load Java to build documentation:

    -- Building documentation (en_US) --
    LANG=C LC_ALL=en_US.UTF-8 SCI_DISABLE_TK=1 SCI_JAVA_ENABLE_HEADLESS=1 ./bin/scilab-adv-cli -noatomsautoload -nb -l en_US -nouserstartup -e "try xmltojar([],[],'en_US');catch disp(lasterror()); exit(-1);end;exit(0);"
    OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x000003461105f000, 2555904, 1) failed; error='Operation not permitted' (errno=1)
    #
    # There is insufficient memory for the Java Runtime Environment to continue.
    # Native memory allocation (malloc) failed to allocate 2555904 bytes for committing reserved memory.
    # An error report file with more information is saved as:
    # /var/tmp/portage/sci-mathematics/scilab-5.5.2/work/scilab-5.5.2/hs_err_pid15863.log
    Makefile:2142: recipe for target 'doc' failed
    make: *** [doc] Error 1
     * ERROR: sci-mathematics/scilab-5.5.2::science failed (compile phase):
     *   emake failed
