### PR TITLE
dev-python/notebook: Don't need setuptools for scripts

### DIFF
--- a/dev-python/notebook/ChangeLog
+++ b/dev-python/notebook/ChangeLog
@@ -2,6 +2,10 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Id$
 
+  22 Sep 2015; Sean Vig <sean.v.775@gmail.com> notebook-4.0.5.ebuild,
+  notebook-9999.ebuild:
+  dev-python/notebook: Don't need setuptools for scripts
+
 *notebook-4.0.5 (22 Sep 2015)
 
   22 Sep 2015; Marius Brehler <marbre@linux.sungazer.de> +notebook-4.0.5.ebuild:

--- a/dev-python/notebook/notebook-4.0.5.ebuild
+++ b/dev-python/notebook/notebook-4.0.5.ebuild
@@ -44,10 +44,6 @@ DEPEND="${RDEPEND}
 	"
 
 python_prepare_all() {
-	sed \
-		-e "/import setup/s:$:\nimport setuptools:g" \
-		-i setup.py || die
-
 	# disable bundled mathjax
 	sed -i 's/^.*MathJax.*$//' bower.json || die
 	sed -i 's/mj(/#mj(/' setupbase.py || die

--- a/dev-python/notebook/notebook-9999.ebuild
+++ b/dev-python/notebook/notebook-9999.ebuild
@@ -43,10 +43,6 @@ DEPEND="${RDEPEND}
 	"
 
 python_prepare_all() {
-	sed \
-		-e "/import setup/s:$:\nimport setuptools:g" \
-		-i setup.py || die
-
 	# disable bundled mathjax
 	sed -i 's/^.*MathJax.*$//' bower.json || die
 	sed -i 's/mj(/#mj(/' setupbase.py || die


### PR DESCRIPTION
See https://github.com/jupyter/notebook/issues/339