### PR TITLE
Update envytools-9999.ebuild

### DIFF
--- a/x11-misc/envytools/envytools-9999.ebuild
+++ b/x11-misc/envytools/envytools-9999.ebuild
@@ -25,6 +25,6 @@ DEPEND="${RDEPEND}
 	sys-devel/bison
 	sys-devel/flex"
 
-DOCS=( README )
+DOCS=( README.rst )
 
 PATCHES=( "${FILESDIR}"/${PN}-bison.patch )


### PR DESCRIPTION
currently the README.rst file is not found during installation:

/usr/bin/install: cannot stat 'README': No such file or directory
!!! dodoc: README does not exist

Proposed Solution:
change "README" to "README.rst"