### PR TITLE
sci-libs/symengine: split out bindings to dev-python/symengine

### DIFF
--- a/dev-python/symengine/ChangeLog
+++ b/dev-python/symengine/ChangeLog
@@ -1,0 +1,9 @@
+# ChangeLog for dev-python/symengine
+# Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
+# $Id$
+
+*symengine-9999 (25 Oct 2015)
+
+  25 Oct 2015; Michael Schubert <mschu.dev@gmail.com> +metadata.xml,
+  +symengine-9999.ebuild:
+  sci-libs/symengine: split out bindings to dev-python/symengine

--- a/dev-python/symengine/metadata.xml
+++ b/dev-python/symengine/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>sci-mathematics</herd>
+  <maintainer>
+    <email>mschu.dev@gmail.com</email>
+    <name>Michael Schubert</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">sympy/symengine.py</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/dev-python/symengine/symengine-9999.ebuild
+++ b/dev-python/symengine/symengine-9999.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+PYTHON_COMPAT=( python{2_7,3_3,3_4,3_5} )
+
+inherit distutils-r1 git-r3
+
+DESCRIPTION="Python wrappers to the symengine C++ library"
+HOMEPAGE="https://github.com/sympy/symengine.py"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/symengine/symengine.py.git"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+
+RDEPEND="
+	dev-python/numpy[${PYTHON_USEDEP}]
+	=sci-libs/symengine-9999"
+DEPEND="${RDEPEND}
+	dev-python/cython[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]"
+
+# if this is not set python2 .so is linked to python3
+DISTUTILS_IN_SOURCE_BUILD=1
+
+python_install_all() {
+	newdoc README.md ${PN}_py.md
+}

--- a/sci-libs/symengine/symengine-9999.ebuild
+++ b/sci-libs/symengine/symengine-9999.ebuild
@@ -4,9 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 )
-
-inherit git-r3 cmake-utils python-single-r1
+inherit git-r3 cmake-utils
 
 DESCRIPTION="Fast symbolic manipulation library, written in C++"
 HOMEPAGE="https://github.com/sympy/symengine"
@@ -16,19 +14,13 @@ EGIT_REPO_URI="https://github.com/sympy/symengine.git"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="boost openmp python threads"
-REQUIRED_USE="
-	python? ( ${PYTHON_REQUIRED_USE} )
-	?? ( openmp threads )"
+IUSE="boost openmp threads"
+REQUIRED_USE="?? ( openmp threads )"
 
 RDEPEND="
 	dev-libs/jemalloc
-	boost? ( dev-libs/boost )
-	python? ( dev-python/numpy[${PYTHON_USEDEP}] )"
-DEPEND="${RDEPEND}
-	python? (
-		dev-python/cython[${PYTHON_USEDEP}]
-		dev-python/setuptools[${PYTHON_USEDEP}] )"
+	boost? ( dev-libs/boost )"
+DEPEND="${RDEPEND}"
 
 CMAKE_BUILD_TYPE=Release
 
@@ -46,7 +38,6 @@ src_configure() {
 		-DCMAKE_INSTALL_PREFIX:PATH="${EPREFIX}"/usr
 		$(cmake-utils_use_with boost)
 		$(cmake-utils_use_with openmp)
-		$(cmake-utils_use_with python)
 	)
 
 	if use threads; then


### PR DESCRIPTION
Upstream split `symengine` into the [C++ library](https://github.com/symengine/symengine), and [external python bindings](https://github.com/symengine/symengine.py).

This ebuild uses a separate package for python support in the development version, that is now compatible with more than one python installation.

(Note: Is is preferable to include the python binding sources in the original ebuild and have a `USE` flag handle its installation instead of a separate package?)