### PR TITLE
sci-physics/root: Update to upstream changes.

### DIFF
--- a/sci-physics/root/ChangeLog
+++ b/sci-physics/root/ChangeLog
@@ -2,6 +2,12 @@
 # Copyright 1999-2015 Gentoo Foundation; Distributed under the GPL v2
 # $Id$
 
+  15 Nov 2015; Oliver Freyermuth <o.freyermuth@googlemail.com>
+  +files/root-6.06.00-nobyte-compile.patch,
+  -files/root-6.00.01-nobyte-compile.patch, root-9999.ebuild:
+  sci-physics/root: Update to upstream changes. New nobyte-compile patch, paths
+  for gl2ps changed,  DOCS files changed.
+
   27 Sep 2015; Oliver Freyermuth <o.freyermuth@googlemail.com>
   -files/root-6.00.01-geocad.patch, root-9999.ebuild:
   sci-physics/root:  Remove geocad-patch, is now upstream.

--- a/sci-physics/root/files/root-6.06.00-nobyte-compile.patch
+++ b/sci-physics/root/files/root-6.06.00-nobyte-compile.patch
@@ -1,33 +1,39 @@
-diff -Naur root.as-needed/bindings/pyroot/Module.mk root/bindings/pyroot/Module.mk
---- root.as-needed/bindings/pyroot/Module.mk	2011-07-10 10:42:48.991561304 +0400
-+++ root/bindings/pyroot/Module.mk	2011-07-10 10:43:21.493339703 +0400
-@@ -48,8 +48,6 @@
- ROOTPY       := $(subst $(MODDIR),$(LPATH),$(ROOTPYS))
- $(LPATH)/%.py: $(MODDIR)/%.py; cp $< $@
+diff --git a/bindings/pyroot/Module.mk b/bindings/pyroot/Module.mk
+index 8c2782d..f41e0aa 100644
+--- a/bindings/pyroot/Module.mk
++++ b/bindings/pyroot/Module.mk
+@@ -65,10 +65,6 @@ $(LPATH)/ROOTaaS/%: $(MODDIR)/ROOTaaS/%
+ 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
+ 	cp -R $< $@
  endif
 -ROOTPYC      := $(ROOTPY:.py=.pyc)
 -ROOTPYO      := $(ROOTPY:.py=.pyo)
+-ROOTAASC     := $(ROOTAAS:.py=.pyc)
+-ROOTAASO     := $(ROOTAAS:.py=.pyo)
  
  # used in the main Makefile
  ALLHDRS      += $(patsubst $(MODDIRI)/%.h,include/%.h,$(PYROOTH))
-@@ -68,10 +66,8 @@
+@@ -87,12 +83,9 @@ INCLUDEFILES += $(PYROOTDEP)
  include/%.h:    $(PYROOTDIRI)/%.h
  		cp $< $@
  
 -%.pyc: %.py;    python -c 'import py_compile; py_compile.compile( "$<" )'
 -%.pyo: %.py;    python -O -c 'import py_compile; py_compile.compile( "$<" )'
- 
+-
 -$(PYROOTLIB):   $(PYROOTO) $(PYROOTDO) $(ROOTPY) $(ROOTPYC) $(ROOTPYO) \
 +$(PYROOTLIB):   $(PYROOTO) $(PYROOTDO) $(ROOTPY) \
-                 $(ROOTLIBSDEP) $(PYTHONLIBDEP)
+                 $(ROOTLIBSDEP) $(PYTHONLIBDEP) \
+-                $(ROOTAAS) $(ROOTAASC) $(ROOTAASO)
++                $(ROOTAAS)
+ 
  		@$(MAKELIB) $(PLATFORM) $(LD) "$(LDFLAGS)" \
  		  "$(SOFLAGS)" libPyROOT.$(SOEXT) $@ \
-@@ -113,7 +109,7 @@
+@@ -138,7 +131,7 @@ clean::         clean-$(MODNAME)
  
  distclean-$(MODNAME): clean-$(MODNAME)
  		@rm -f $(PYROOTDEP) $(PYROOTDS) $(PYROOTDH) $(PYROOTLIB) \
 -		   $(ROOTPY) $(ROOTPYC) $(ROOTPYO) $(PYROOTMAP) \
 +		   $(ROOTPY) $(PYROOTMAP) \
  		   $(PYROOTPYD) $(PYTHON64DEP) $(PYTHON64)
+ 		@rm -rf $(LPATH)/ROOTaaS bin/ROOTaaS
  
- distclean::     distclean-$(MODNAME)

--- a/sci-physics/root/root-9999.ebuild
+++ b/sci-physics/root/root-9999.ebuild
@@ -196,7 +196,7 @@ src_prepare() {
 		"${FILESDIR}"/${PN}-5.32.00-chklib64.patch \
 		"${FILESDIR}"/${PN}-5.34.13-unuran.patch \
 		"${FILESDIR}"/${PN}-6.00.01-dotfont.patch \
-		"${FILESDIR}"/${PN}-6.00.01-nobyte-compile.patch \
+		"${FILESDIR}"/${PN}-6.06.00-nobyte-compile.patch \
 		"${FILESDIR}"/${PN}-6.00.01-llvm.patch
 
 	# make sure we use system libs and headers
@@ -210,7 +210,7 @@ src_prepare() {
 	LANG=C LC_ALL=C find core/zip -type f -name "[a-z]*" -print0 | \
 		xargs -0 rm || die
 	rm -r core/lzma/src/*.tar.gz || die
-	rm graf3d/gl/{inc,src}/gl2ps.* || die
+	rm graf3d/gl/src/gl2ps.* || die
 	sed -i -e 's/^GLLIBS *:= .* $(OPENGLLIB)/& -lgl2ps/' \
 		graf3d/gl/Module.mk || die
 
@@ -397,6 +397,7 @@ cleanup_install() {
 }
 
 src_install() {
+	DOCS=($(find README/* -maxdepth 1 -type f))
 	default
 	dodoc README.md
 


### PR DESCRIPTION
New nobyte-compile patch, paths for gl2ps changed,
DOCS files changed.

Package-Manager: portage-2.2.24

The `DOCS=($(find README/* -maxdepth 1 -type f))` is necessary since they have now a folder "README" in their repo which breaks with EAPI=4 by default, that folder contains the usual files like INSTALL etc. 