### PR TITLE
fix dependency on boost[python]

### DIFF
--- a/sci-libs/rdkit/rdkit-2015.03.1.ebuild
+++ b/sci-libs/rdkit/rdkit-2015.03.1.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="+python -static-libs"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
-RDEPEND="dev-libs/boost
+RDEPEND="dev-libs/boost[python]
 	python? (
 		dev-libs/boost[${PYTHON_USEDEP}]
 		dev-python/numpy[${PYTHON_USEDEP}]

--- a/sci-libs/rdkit/rdkit-2015.03.1.ebuild
+++ b/sci-libs/rdkit/rdkit-2015.03.1.ebuild
@@ -18,9 +18,9 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="+python -static-libs"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
-RDEPEND="dev-libs/boost[python]
+RDEPEND="dev-libs/boost
 	python? (
-		dev-libs/boost[${PYTHON_USEDEP}]
+		dev-libs/boost[python,${PYTHON_USEDEP}]
 		dev-python/numpy[${PYTHON_USEDEP}]
 	)
 	>=dev-db/sqlite-3"

--- a/sci-libs/rdkit/rdkit-9999.ebuild
+++ b/sci-libs/rdkit/rdkit-9999.ebuild
@@ -21,7 +21,7 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 RDEPEND="dev-libs/boost
 	python? (
-		dev-libs/boost[${PYTHON_USEDEP}]
+		dev-libs/boost[python,${PYTHON_USEDEP}]
 		dev-python/numpy[${PYTHON_USEDEP}]
 	)
 	>=dev-db/sqlite-3"


### PR DESCRIPTION
rdkit should requires that boost is installed with python support.