### PR TITLE
eclass/alternatives-2.eclass: support Prefix.

### DIFF
--- a/eclass/alternatives-2.eclass
+++ b/eclass/alternatives-2.eclass
@@ -33,9 +33,9 @@ esac
 
 DEPEND=">=app-admin/eselect-1.4.5-r102"
 RDEPEND="${DEPEND}
-	!app-admin/eselect-blas
-	!app-admin/eselect-cblas
-	!app-admin/eselect-lapack"
+	!app-eselect/eselect-blas
+	!app-eselect/eselect-cblas
+	!app-eselect/eselect-lapack"
 
 # @ECLASS-VARIABLE: ALTERNATIVES_DIR
 # @INTERNAL
@@ -58,7 +58,7 @@ alternatives_for() {
 
 	dodir /etc/env.d/alternatives
 
-	ALTERNATIVESDIR_ROOTLESS="${ED}/etc/env.d/alternatives" \
+	ALTERNATIVESDIR_ROOT="${D%/}" \
 		eselect alternatives add ${@} || die
 
 	ALTERNATIVES_CREATED+=( ${1} )


### PR DESCRIPTION
eclass/alternatives-2.eclass: support Prefix. Fixes #453.

  Use ALTERNATIVESDIR_ROOT for ${ED}.

  app-admin/eselect-* has been renamed to app-select/eselect-*.

  recover colon-separated pairs for ALTERNATIVES_CREATED.

files/eselect-1.4.5-alternatives.patch: refresh patch for Prefix.