### PR TITLE
sys-cluster/modules: fix typo. /etc/modulefiles.

### DIFF
--- a/sys-cluster/modules/modules-3.2.10-r1.ebuild
+++ b/sys-cluster/modules/modules-3.2.10-r1.ebuild
@@ -57,5 +57,5 @@ src_install() {
 	exeinto /usr/share/Modules/bin
 	doexe "${FILESDIR}"/createmodule.{sh,py}
 	dosym /usr/share/Modules/init/csh /etc/profile.d/modules.csh
-	dodir /etc/modulesfiles
+	dodir /etc/modulefiles
 }


### PR DESCRIPTION
The configuration directory of sys-cluster/modules is /etc/modulefiles, as noted in the manpage and pointed by MODULEPATH.