### PR TITLE
dev-python/pydotplus: deleted erroneous source dir

### DIFF
--- a/dev-python/pydotplus/pydotplus-2.0.2.ebuild
+++ b/dev-python/pydotplus/pydotplus-2.0.2.ebuild
@@ -24,8 +24,6 @@ RDEPEND="
 	dev-python/pyparsing[${PYTHON_USEDEP}]
 	"
 
-S="${WORKDIR}/${PN}-${MY_PV}"
-
 src_test() {
 	${PYTHON} -m unittest discover || die
 }


### PR DESCRIPTION
Repairs pydotplus (it currently does not build due to unnecessary and incorrect source dir specificaion).