### PR TITLE
sci-biology/abyss: fix automagic haskell deps, bug #534412

### DIFF
--- a/sci-biology/abyss/abyss-1.3.6-r1.ebuild
+++ b/sci-biology/abyss/abyss-1.3.6-r1.ebuild
@@ -14,14 +14,21 @@ SRC_URI="http://www.bcgsc.ca/downloads/abyss/${P}.tar.gz"
 
 LICENSE="abyss"
 SLOT="0"
-IUSE="+mpi openmp"
+IUSE="+mpi openmp misc-haskell"
 KEYWORDS="~amd64 ~x86"
 
-DEPEND="
+RDEPEND="
 	dev-cpp/sparsehash
 	dev-libs/boost
-	mpi? ( virtual/mpi )"
-RDEPEND="${DEPEND}"
+	misc-haskell? ( dev-libs/gmp:0=
+			virtual/libffi:0=
+	)
+	mpi? ( virtual/mpi )
+"
+DEPEND="${RDEPEND}
+	misc-haskell? ( dev-lang/ghc
+			dev-haskell/mmap )
+"
 
 # todo: --enable-maxk=N configure option
 # todo: fix automagic mpi toggling
@@ -40,6 +47,10 @@ src_prepare() {
 }
 
 src_configure() {
+	# disable building haskell tool Misc/samtobreak
+	# unless request by user: bug #534412
+	use misc-haskell || export ac_cv_prog_ac_ct_GHC=
+
 	local myeconfargs=(
 		--docdir="${EPREFIX}/usr/share/doc/${PF}"
 		$(use_enable openmp)

--- a/sci-biology/abyss/metadata.xml
+++ b/sci-biology/abyss/metadata.xml
@@ -5,4 +5,11 @@
     <email>sci-biology@gentoo.org</email>
     <name>Gentoo Biology Project</name>
   </maintainer>
+  <maintainer type="project">
+    <email>haskell@gentoo.org</email>
+    <name>Gentoo Haskell</name>
+  </maintainer>
+  <use>
+    <flag name='misc-haskell'>build abyss-samtobreak tool, pull in haskell toolchain</flag>
+  </use>
 </pkgmetadata>


### PR DESCRIPTION
It's a ::gentoo change a50e1769e82e28dedb16083ac9136f17f9af2297

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/534412

Package-Manager: portage-2.2.28