### PR TITLE
sci-visualization/mricrogl: new versioned ebuild

### DIFF
--- a/sci-visualization/mricrogl/mricrogl-1.0.20151111.ebuild
+++ b/sci-visualization/mricrogl/mricrogl-1.0.20151111.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+inherit git-r3 gnome2-utils
+
+DESCRIPTION="A simle medical imaging visualization tool"
+HOMEPAGE="https://github.com/neurolabusc/MRIcroGL"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/neurolabusc/MRIcroGL.git"
+EGIT_COMMIT="${PV}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND=""
+DEPEND="dev-lang/fpc
+	dev-lang/lazarus"
+
+src_compile() {
+	lazbuild -B --lazarusdir="/usr/share/lazarus/" simplelaz.lpi || die
+}
+
+src_install() {
+	dobin MRIcroGL
+
+	insinto /usr/bin/shaders
+	doins shaders/*.txt
+
+	doicon -s scalable mricrogl.svg
+	make_desktop_entry MRIcroGL MRIcroGL /usr/share/icons/hicolor/scalable/apps/mricrogl.svg
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+}
+pkg_postrm() {
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
Especially relevant since we currently have no working MRIcroGL ebuild, as per issu #618