### PR TITLE
dev-python/pydotplus: added 3.4 compatibility

### DIFF
--- a/dev-python/pydotplus/pydotplus-2.0.2.ebuild
+++ b/dev-python/pydotplus/pydotplus-2.0.2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python{2_7,3_4} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
We need to let portage know that this package works on 3.4 so that 3.4 compatible ebuilds that depend on it are considered valid (e.g. #617 ).