### PR TITLE
sci-physics/root-9999: current master needs write access to /dev/random

### DIFF
--- a/sci-physics/root/root-9999.ebuild
+++ b/sci-physics/root/root-9999.ebuild
@@ -397,6 +397,10 @@ cleanup_install() {
 }
 
 src_install() {
+	# Write access to /dev/random is required to run root.exe
+	# More information at https://sft.its.cern.ch/jira/browse/ROOT-8146
+	addwrite /dev/random
+
 	DOCS=($(find README/* -maxdepth 1 -type f))
 	default
 	dodoc README.md


### PR DESCRIPTION
Needed at runtime of the ROOT interpreter when JITting code,
thus also necessary to build examples (and the hsimple-target).
Further details upstream: https://sft.its.cern.ch/jira/browse/ROOT-8146
Since write-access needs to actually work, addpredict is insufficient.
Writing to /dev/random should not be a security concern
(entroy is unchanged).