### PR TITLE
fix SRC_URI

### DIFF
--- a/sci-biology/hmmer/hmmer-3.1_beta2.ebuild
+++ b/sci-biology/hmmer/hmmer-3.1_beta2.ebuild
@@ -1,15 +1,16 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit eutils
 
-MY_PV="3.1b2"
+MY_PV=${PV/_beta/b}
+
 DESCRIPTION="Sequence analysis using profile hidden Markov models"
 HOMEPAGE="http://hmmer.janelia.org/"
-SRC_URI="ftp://selab.janelia.org/pub/software/hmmer3/"${MY_PV}"/"${PN}"-"${MY_PV}".tar.gz"
+SRC_URI="http://eddylab.org/software/hmmer3/${MY_PV}/${PN}-${MY_PV}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"


### PR DESCRIPTION
as the src seems to move on an other server
by the way fix:
- the version is not hardcoded anymore, use shell string substitution and
  gentoo variable PV to compute the version for the url
- bump EAPI to version 6
- fix copyright
