### PR TITLE
Add support for multilib mpi to mpi.eclass

### DIFF
--- a/eclass/mpi.eclass
+++ b/eclass/mpi.eclass
@@ -56,6 +56,9 @@ mpi_classed() {
 	[[ ${CATEGORY} == mpi-* ]]
 }
 
+#empi has no support for multilib yet
+mpi_classed && [[ ${_MULTILIB_BUILD} ]] && REQUIRED_USE="abi_x86_64? ( !abi_x86_32 )"
+
 # @FUNCTION: mpi_class
 # @RETURN: The name of the current class, or nothing if unclassed.
 mpi_class() {

--- a/sys-cluster/mpich/mpich-3.2-r2.ebuild
+++ b/sys-cluster/mpich/mpich-3.2-r2.ebuild
@@ -16,7 +16,7 @@ SRC_URI="http://www.mpich.org/static/downloads/${PV}/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="mpich"
-KEYWORDS=""
+KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="+cxx doc fortran mpi-threads romio threads"
 
 COMMON_DEPEND="

--- a/sys-cluster/mpich/mpich-3.2-r2.ebuild
+++ b/sys-cluster/mpich/mpich-3.2-r2.ebuild
@@ -1,0 +1,120 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+FORTRAN_NEEDED=fortran
+FORTRAN_STANDARD="77 90"
+
+inherit fortran-2 multilib-minimal mpi
+
+MY_PV=${PV/_/}
+DESCRIPTION="A high performance and portable MPI implementation"
+HOMEPAGE="http://www.mpich.org/"
+SRC_URI="http://www.mpich.org/static/downloads/${PV}/${P}.tar.gz"
+
+SLOT="0"
+LICENSE="mpich"
+KEYWORDS=""
+IUSE="+cxx doc fortran mpi-threads romio threads"
+REQUIRED_USE="mpi-threads? ( threads )"
+
+COMMON_DEPEND="
+	>=dev-libs/libaio-0.3.109-r5[${MULTILIB_USEDEP}]
+	>=sys-apps/hwloc-1.10.0-r2[${MULTILIB_USEDEP}]
+	romio? ( net-fs/nfs-utils )
+	$(mpi_imp_deplist)"
+
+DEPEND="${COMMON_DEPEND}
+	dev-lang/perl
+	sys-devel/libtool"
+
+RDEPEND="${COMMON_DEPEND}"
+
+S="${WORKDIR}"/${PN}-${MY_PV}
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/mpicxx.h
+	/usr/include/mpi.h
+	/usr/include/opa_config.h
+)
+
+src_prepare() {
+	default
+
+	# Using MPICHLIB_LDFLAGS doesn't seem to fully work.
+	sed -i 's| *@WRAPPER_LDFLAGS@ *||' \
+		src/packaging/pkgconfig/mpich.pc.in \
+		src/env/*.in \
+		|| die
+}
+
+multilib_src_configure() {
+	# The configure statements can be somewhat confusing, as they
+	# don't all show up in the top level configure, however, they
+	# are picked up in the children directories.
+
+	export MPICHLIB_CFLAGS="${CFLAGS}"
+	export MPICHLIB_CPPFLAGS="${CPPFLAGS}"
+	export MPICHLIB_CXXFLAGS="${CXXFLAGS}"
+	export MPICHLIB_FFLAGS="${FFLAGS}"
+	export MPICHLIB_FCFLAGS="${FCFLAGS}"
+	export MPICHLIB_LDFLAGS="${LDFLAGS}"
+	unset CFLAGS CPPFLAGS CXXFLAGS FFLAGS FCFLAGS LDFLAGS
+
+	ECONF_SOURCE=${S} $(mpi_econf_args) econf \
+		--enable-shared \
+		--sysconfdir="${EPREFIX}/etc/${PN}" \
+		--with-hwloc-prefix="${EPREFIX}/usr" \
+		--enable-threads=$(usex mpi-threads runtime single) \
+		--with-thread-package=$(usex threads pthreads none) \
+		--with-pm=hydra \
+		--disable-fast \
+		--enable-versioning \
+		--with-hwloc-prefix=/usr \
+		$(mpi_classed && echo "--docdir=$(mpi_root)/usr/share/doc/${PF}") \
+		$(use_enable romio) \
+		$(use_enable cxx) \
+		$(multilib_native_use_enable fortran fortran all)
+}
+
+multilib_src_test() {
+	emake -j1 check
+}
+
+multilib_src_install() {
+	default
+
+	# fortran header cannot be wrapped (bug #540508), workaround part 1
+	if multilib_is_native_abi && use fortran; then
+		mkdir "${T}"/fortran || die
+		mv "${ED}"usr/include/mpif* "${T}"/fortran || die
+		mv "${ED}"usr/include/*.mod "${T}"/fortran || die
+	else
+		# some fortran files get installed unconditionally
+		rm "${ED}"usr/include/mpif* "${ED}"usr/include/*.mod || die
+	fi
+}
+
+multilib_src_install_all() {
+	# fortran header cannot be wrapped (bug #540508), workaround part 2
+	if use fortran; then
+		mv "${T}"/fortran/* "${ED}"usr/include || die
+	fi
+
+	mpi_dodir /usr/share/doc/${PF}
+	mpi_dodoc COPYRIGHT README{,.envvar} CHANGES RELEASE_NOTES
+	mpi_newdoc src/pm/hydra/README README.hydra
+	if use romio; then
+		mpi_newdoc src/mpi/romio/README README.romio
+	fi
+
+	local d=$(echo ${ED}/$(mpi_root)/ | sed 's,///*,/,g')
+	if ! use doc; then
+		rm -rf "${d}"usr/share/doc/${PF}/www* || die
+	fi
+
+	MPI_ESELECT_FILE="eselect.mpi.mpich"
+	mpi_imp_add_eselect
+}

--- a/sys-cluster/mpich/mpich-3.2-r2.ebuild
+++ b/sys-cluster/mpich/mpich-3.2-r2.ebuild
@@ -18,7 +18,6 @@ SLOT="0"
 LICENSE="mpich"
 KEYWORDS=""
 IUSE="+cxx doc fortran mpi-threads romio threads"
-REQUIRED_USE="mpi-threads? ( threads )"
 
 COMMON_DEPEND="
 	>=dev-libs/libaio-0.3.109-r5[${MULTILIB_USEDEP}]
@@ -53,7 +52,22 @@ src_prepare() {
 multilib_src_configure() {
 	# The configure statements can be somewhat confusing, as they
 	# don't all show up in the top level configure, however, they
-	# are picked up in the children directories.
+	# are picked up in the children directories.  Hence the separate
+	# local vars.
+
+	local c=
+	if use mpi-threads; then
+		# MPI-THREAD requries threading.
+		c="${c} --with-thread-package=pthreads"
+		c="${c} --enable-threads=runtime"
+	else
+		if use threads ; then
+			c="${c} --with-thread-package=pthreads"
+		else
+			c="${c} --with-thread-package=none"
+		fi
+		c="${c} --enable-threads=single"
+	fi
 
 	export MPICHLIB_CFLAGS="${CFLAGS}"
 	export MPICHLIB_CPPFLAGS="${CPPFLAGS}"
@@ -67,8 +81,7 @@ multilib_src_configure() {
 		--enable-shared \
 		--sysconfdir="${EPREFIX}/etc/${PN}" \
 		--with-hwloc-prefix="${EPREFIX}/usr" \
-		--enable-threads=$(usex mpi-threads runtime single) \
-		--with-thread-package=$(usex threads pthreads none) \
+		${c} \
 		--with-pm=hydra \
 		--disable-fast \
 		--enable-versioning \

--- a/sys-cluster/mpich/mpich-3.2-r2.ebuild
+++ b/sys-cluster/mpich/mpich-3.2-r2.ebuild
@@ -89,18 +89,18 @@ multilib_src_install() {
 	# fortran header cannot be wrapped (bug #540508), workaround part 1
 	if multilib_is_native_abi && use fortran; then
 		mkdir "${T}"/fortran || die
-		mv "${ED}"usr/include/mpif* "${T}"/fortran || die
-		mv "${ED}"usr/include/*.mod "${T}"/fortran || die
+		mv "${ED}"/$(mpi_root)/usr/include/mpif* "${T}"/fortran || die
+		mv "${ED}"/$(mpi_root)/usr/include/*.mod "${T}"/fortran || die
 	else
 		# some fortran files get installed unconditionally
-		rm "${ED}"usr/include/mpif* "${ED}"usr/include/*.mod || die
+		rm "${ED}"/$(mpi_root)/usr/include/mpif* "${ED}"usr/include/*.mod || die
 	fi
 }
 
 multilib_src_install_all() {
 	# fortran header cannot be wrapped (bug #540508), workaround part 2
 	if use fortran; then
-		mv "${T}"/fortran/* "${ED}"usr/include || die
+		mv "${T}"/fortran/* "${ED}"/$(mpi_root)/usr/include || die
 	fi
 
 	mpi_dodir /usr/share/doc/${PF}

--- a/sys-cluster/mpich/mpich-3.2-r2.ebuild
+++ b/sys-cluster/mpich/mpich-3.2-r2.ebuild
@@ -69,6 +69,13 @@ multilib_src_configure() {
 		c="${c} --enable-threads=single"
 	fi
 
+	if ! mpi_classed; then
+		c="${c} --sysconfdir=${EPREFIX}/etc/${PN}"
+		c="${c} --docdir=${EPREFIX}/usr/share/doc/${PF}"
+	else
+		c="${c} --docdir=$(mpi_root)/usr/share/doc/${PF}"
+	fi
+
 	export MPICHLIB_CFLAGS="${CFLAGS}"
 	export MPICHLIB_CPPFLAGS="${CPPFLAGS}"
 	export MPICHLIB_CXXFLAGS="${CXXFLAGS}"
@@ -77,16 +84,14 @@ multilib_src_configure() {
 	export MPICHLIB_LDFLAGS="${LDFLAGS}"
 	unset CFLAGS CPPFLAGS CXXFLAGS FFLAGS FCFLAGS LDFLAGS
 
-	ECONF_SOURCE=${S} $(mpi_econf_args) econf \
+	ECONF_SOURCE=${S} econf $(mpi_econf_args) \
 		--enable-shared \
-		--sysconfdir="${EPREFIX}/etc/${PN}" \
 		--with-hwloc-prefix="${EPREFIX}/usr" \
 		${c} \
 		--with-pm=hydra \
 		--disable-fast \
 		--enable-versioning \
 		--with-hwloc-prefix=/usr \
-		$(mpi_classed && echo "--docdir=$(mpi_root)/usr/share/doc/${PF}") \
 		$(use_enable romio) \
 		$(use_enable cxx) \
 		$(multilib_native_use_enable fortran fortran all)

--- a/sys-cluster/openmpi/openmpi-1.10.3-r2.ebuild
+++ b/sys-cluster/openmpi/openmpi-1.10.3-r2.ebuild
@@ -33,7 +33,7 @@ HOMEPAGE="http://www.open-mpi.org"
 SRC_URI="http://www.open-mpi.org/software/ompi/v$(get_version_component_range 1-2)/downloads/${MY_P}.tar.bz2"
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux"
 IUSE="cma cuda +cxx elibc_FreeBSD fortran heterogeneous ipv6 java mpi-threads numa romio threads vt
 	${IUSE_OPENMPI_FABRICS} ${IUSE_OPENMPI_RM} ${IUSE_OPENMPI_OFED_FEATURES}"
 

--- a/sys-cluster/openmpi/openmpi-1.10.3-r2.ebuild
+++ b/sys-cluster/openmpi/openmpi-1.10.3-r2.ebuild
@@ -1,0 +1,193 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+FORTRAN_NEEDED=fortran
+
+inherit cuda flag-o-matic fortran-2 java-pkg-opt-2 toolchain-funcs versionator multilib-minimal mpi
+
+MY_P=${P/-mpi}
+S=${WORKDIR}/${MY_P}
+
+IUSE_OPENMPI_FABRICS="
+	openmpi_fabrics_ofed
+	openmpi_fabrics_knem
+	openmpi_fabrics_psm"
+
+IUSE_OPENMPI_RM="
+	openmpi_rm_pbs
+	openmpi_rm_slurm"
+
+IUSE_OPENMPI_OFED_FEATURES="
+	openmpi_ofed_features_control-hdr-padding
+	openmpi_ofed_features_connectx-xrc
+	openmpi_ofed_features_udcm
+	openmpi_ofed_features_rdmacm
+	openmpi_ofed_features_dynamic-sl
+	openmpi_ofed_features_failover"
+
+DESCRIPTION="A high-performance message passing library (MPI)"
+HOMEPAGE="http://www.open-mpi.org"
+SRC_URI="http://www.open-mpi.org/software/ompi/v$(get_version_component_range 1-2)/downloads/${MY_P}.tar.bz2"
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS=""
+IUSE="cma cuda +cxx elibc_FreeBSD fortran heterogeneous ipv6 java mpi-threads numa romio threads vt
+	${IUSE_OPENMPI_FABRICS} ${IUSE_OPENMPI_RM} ${IUSE_OPENMPI_OFED_FEATURES}"
+
+REQUIRED_USE="openmpi_rm_slurm? ( !openmpi_rm_pbs )
+	openmpi_rm_pbs? ( !openmpi_rm_slurm )
+	openmpi_fabrics_psm? ( openmpi_fabrics_ofed )
+	openmpi_ofed_features_control-hdr-padding? ( openmpi_fabrics_ofed )
+	openmpi_ofed_features_connectx-xrc? ( openmpi_fabrics_ofed )
+	openmpi_ofed_features_udcm? ( openmpi_fabrics_ofed )
+	openmpi_ofed_features_rdmacm? ( openmpi_fabrics_ofed )
+	openmpi_ofed_features_dynamic-sl? ( openmpi_fabrics_ofed )
+	openmpi_ofed_features_failover? ( openmpi_fabrics_ofed )"
+
+MPI_UNCLASSED_DEP_STR="
+	vt? (
+		!dev-libs/libotf
+		!app-text/lcdf-typetools
+	)"
+
+CDEPEND="
+	>=dev-libs/libevent-2.0.21[${MULTILIB_USEDEP}]
+	dev-libs/libltdl:0[${MULTILIB_USEDEP}]
+	>=sys-apps/hwloc-1.10.0-r2[${MULTILIB_USEDEP},numa?]
+	>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]
+	cuda? ( >=dev-util/nvidia-cuda-toolkit-6.5.19-r1 )
+	elibc_FreeBSD? ( dev-libs/libexecinfo )
+	openmpi_fabrics_ofed? ( sys-fabric/ofed:* )
+	openmpi_fabrics_knem? ( sys-cluster/knem )
+	openmpi_fabrics_psm? ( sys-fabric/infinipath-psm:* )
+	openmpi_rm_pbs? ( sys-cluster/torque )
+	openmpi_rm_slurm? ( sys-cluster/slurm )
+	openmpi_ofed_features_rdmacm? ( sys-fabric/librdmacm:* )
+	$(mpi_imp_deplist)"
+
+RDEPEND="${CDEPEND}
+	java? ( >=virtual/jre-1.6 )"
+
+DEPEND="${CDEPEND}
+	java? ( >=virtual/jdk-1.6 )"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/mpi.h
+)
+
+pkg_setup() {
+	fortran-2_pkg_setup
+	java-pkg-opt-2_pkg_setup
+	MPI_ESELECT_FILE="eselect.mpi.openmpi"
+
+	if use mpi-threads; then
+		ewarn
+		ewarn "WARNING: use of MPI_THREAD_MULTIPLE is still disabled by"
+		ewarn "default and officially unsupported by upstream."
+		ewarn "You may stop now and set USE=-mpi-threads"
+		ewarn
+	fi
+
+	elog
+	elog "OpenMPI has an overwhelming count of configuration options."
+	elog "Don't forget the EXTRA_ECONF environment variable can let you"
+	elog "specify configure options if you find them necessary."
+	elog
+}
+
+src_prepare() {
+	default
+
+	# Necessary for scalibility, see
+	# http://www.open-mpi.org/community/lists/users/2008/09/6514.php
+	if use threads; then
+		echo 'oob_tcp_listen_mode = listen_thread' \
+			>> opal/etc/openmpi-mca-params.conf || die
+	fi
+}
+
+multilib_src_configure() {
+	if use java; then
+		# We must always build with the right -source and -target
+		# flags. Passing flags to javac isn't explicitly supported here
+		# but we can cheat by overriding the configure test for javac.
+		export ac_cv_path_JAVAC="$(java-pkg_get-javac) $(java-pkg_javac-args)"
+	fi
+
+	ECONF_SOURCE=${S} econf $(mpi_econf_args) \
+		--sysconfdir="${EPREFIX}/etc/${PN}" \
+		--enable-pretty-print-stacktrace \
+		--enable-orterun-prefix-by-default \
+		--with-hwloc="${EPREFIX}/usr" \
+		--with-libltdl="${EPREFIX}/usr" \
+		--enable-mpi-fortran=$(usex fortran all no) \
+		$(usex !vt --enable-contrib-no-build=vt "") \
+		$(use_enable cxx mpi-cxx) \
+		$(use_with cma) \
+		$(use_with cuda cuda "${EPREFIX}"/opt/cuda) \
+		$(use_enable romio io-romio) \
+		$(use_enable heterogeneous) \
+		$(use_enable ipv6) \
+		$(multilib_native_use_enable java) \
+		$(multilib_native_use_enable java mpi-java) \
+		$(multilib_native_use_enable mpi-threads mpi-thread-multiple) \
+		$(multilib_native_use_with openmpi_fabrics_ofed verbs "${EPREFIX}"/usr) \
+		$(multilib_native_use_with openmpi_fabrics_knem knem "${EPREFIX}"/usr) \
+		$(multilib_native_use_with openmpi_fabrics_psm psm "${EPREFIX}"/usr) \
+		$(multilib_native_use_enable openmpi_ofed_features_control-hdr-padding openib-control-hdr-padding) \
+		$(multilib_native_use_enable openmpi_ofed_features_connectx-xrc openib-connectx-xrc) \
+		$(multilib_native_use_enable openmpi_ofed_features_rdmacm openib-rdmacm) \
+		$(multilib_native_use_enable openmpi_ofed_features_udcm openib-udcm) \
+		$(multilib_native_use_enable openmpi_ofed_features_dynamic-sl openib-dynamic-sl) \
+		$(multilib_native_use_enable openmpi_ofed_features_failover btl-openib-failover) \
+		$(multilib_native_use_with openmpi_rm_pbs tm) \
+		$(multilib_native_use_with openmpi_rm_slurm slurm)
+}
+
+multilib_src_test() {
+	# Doesn't work with the default src_test as the dry run (-n) fails.
+	emake -j1 check
+}
+
+multilib_src_install() {
+	default
+
+	# fortran header cannot be wrapped (bug #540508), workaround part 1
+	if multilib_is_native_abi && use fortran; then
+		mkdir "${T}"/fortran || die
+		mv "${ED}"usr/include/mpif* "${T}"/fortran || die
+	else
+		# some fortran files get installed unconditionally
+		rm "${ED}"usr/include/mpif* "${ED}"usr/bin/mpif* || die
+	fi
+}
+
+multilib_src_install_all() {
+	# From USE=vt see #359917
+	rm -rf "${ED}"/$(mpi_root)/usr/share/libtool &> /dev/null
+
+	# fortran header cannot be wrapped (bug #540508), workaround part 2
+	if use fortran; then
+		mv "${T}"/fortran/mpif* "${ED}"usr/include || die
+	fi
+
+	# Avoid collisions with libevent
+	rm -rf "${ED}"/$(mpi_root)/usr/include/event2 &> /dev/null || die
+
+	# Remove la files, no static libs are installed and we have pkg-config
+	find "${ED}" -name '*.la' -delete || die
+
+	if use java; then
+		local mpi_jar="${ED}"/$(mpi_root)/usr/$(get_libdir)/mpi.jar
+		java-pkg_dojar "${mpi_jar}"
+		# We don't want to install the jar file twice
+		# so let's clean after ourselves.
+		rm "${mpi_jar}" || die
+	fi
+
+	mpi_dodoc README AUTHORS NEWS VERSION
+	mpi_imp_add_eselect
+}

--- a/sys-cluster/openmpi/openmpi-1.10.3-r2.ebuild
+++ b/sys-cluster/openmpi/openmpi-1.10.3-r2.ebuild
@@ -158,10 +158,10 @@ multilib_src_install() {
 	# fortran header cannot be wrapped (bug #540508), workaround part 1
 	if multilib_is_native_abi && use fortran; then
 		mkdir "${T}"/fortran || die
-		mv "${ED}"usr/include/mpif* "${T}"/fortran || die
+		mv "${ED}"/$(mpi_root)/usr/include/mpif* "${T}"/fortran || die
 	else
 		# some fortran files get installed unconditionally
-		rm "${ED}"usr/include/mpif* "${ED}"usr/bin/mpif* || die
+		rm "${ED}"/$(mpi_root)/usr/include/mpif* "${ED}"usr/bin/mpif* || die
 	fi
 }
 
@@ -171,7 +171,7 @@ multilib_src_install_all() {
 
 	# fortran header cannot be wrapped (bug #540508), workaround part 2
 	if use fortran; then
-		mv "${T}"/fortran/mpif* "${ED}"usr/include || die
+		mv "${T}"/fortran/mpif* "${ED}"/$(mpi_root)/usr/include || die
 	fi
 
 	# Avoid collisions with libevent


### PR DESCRIPTION
See [bug #519700](https://bugs.gentoo.org/show_bug.cgi?id=519700) for details