### PR TITLE
sci-biology/abyss: tweak for gcc-6, bug #594254

### DIFF
--- a/sci-biology/abyss/abyss-1.9.0.ebuild
+++ b/sci-biology/abyss/abyss-1.9.0.ebuild
@@ -33,6 +33,7 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${P}-ac_prog_ar.patch
+	"${FILESDIR}"/${P}-gcc-6.patch
 )
 
 src_prepare() {

--- a/sci-biology/abyss/files/abyss-1.9.0-gcc-6.patch
+++ b/sci-biology/abyss/files/abyss-1.9.0-gcc-6.patch
@@ -1,0 +1,34 @@
+diff --git a/DataBase/db-csv.cc b/DataBase/db-csv.cc
+index 05cac19..48e3b44 100644
+--- a/DataBase/db-csv.cc
++++ b/DataBase/db-csv.cc
+@@ -18,11 +18,11 @@ static const char TABLE_LIST[] =
+ typedef vector<string> vs;
+ 
+ static bool existFile(const char* f)
+ {
+ 	ifstream file(f);
+-	return file;
++	return bool(file);
+ }
+ 
+ template <typename D>
+ static bool existTable(
+ 		D& db, const string& t)
+diff --git a/SimpleGraph/SimpleGraph.cpp b/SimpleGraph/SimpleGraph.cpp
+index 373ec70..0a9ebd3 100644
+--- a/SimpleGraph/SimpleGraph.cpp
++++ b/SimpleGraph/SimpleGraph.cpp
+@@ -645,11 +645,11 @@ static void* worker(void* pArg)
+ 	for (;;) {
+ 		/** Lock the input stream. */
+ 		static pthread_mutex_t inMutex = PTHREAD_MUTEX_INITIALIZER;
+ 		pthread_mutex_lock(&inMutex);
+ 		EstimateRecord er;
+-		bool good = (*arg.in) >> er;
++		bool good = bool((*arg.in) >> er);
+ 		pthread_mutex_unlock(&inMutex);
+ 		if (!good)
+ 			break;
+ 
+ 		// Flip the anterior distance estimates.


### PR DESCRIPTION
Build failed as:
```
    In file included from AssemblyAlgorithms.cpp:4:0:
    ../DataLayer/FastaReader.h: In member function ‘FastaReader::operator void*() const’:
    ../DataLayer/FastaReader.h:49:35: error: cannot convert ‘std::istream {aka std::basic_istream<char>}’ to ‘void*’ ...
       operator void*() const { return m_in; }
                                       ^~~~
```

In the following source:

```c++
   static bool existFile(const char* f)
   {
        ifstream file(f);
        return file;
   }

```

c++98 provides file->operator void*()
c++11 provides file->explicit operator bool()

Hence the failure on c++11.

The change adds explicit casts around istream.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/594254

Package-Manager: portage-2.3.0