### PR TITLE
sci-libs/nipype: setup_requires patch for python3 and configparser

### DIFF
--- a/sci-libs/nipype/nipype-0.12.0.ebuild
+++ b/sci-libs/nipype/nipype-0.12.0.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/nibabel[${PYTHON_USEDEP}]
 	test? ( dev-python/mock[${PYTHON_USEDEP}] )
-        "
+	"
 RDEPEND="
 	dev-python/networkx[${PYTHON_USEDEP}]
 	dev-python/pydotplus[${PYTHON_USEDEP}]

--- a/sci-libs/nipype/nipype-0.12.1.ebuild
+++ b/sci-libs/nipype/nipype-0.12.1.ebuild
@@ -24,7 +24,7 @@ DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/nibabel[${PYTHON_USEDEP}]
 	test? ( dev-python/mock[${PYTHON_USEDEP}] )
-        "
+	"
 RDEPEND="
 	dev-python/networkx[${PYTHON_USEDEP}]
 	dev-python/pydotplus[${PYTHON_USEDEP}]

--- a/sci-libs/nipype/nipype-9999.ebuild
+++ b/sci-libs/nipype/nipype-9999.ebuild
@@ -26,6 +26,7 @@ DEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	sci-libs/nibabel[${PYTHON_USEDEP}]
 	test? ( dev-python/mock[${PYTHON_USEDEP}] )
+	$(python_gen_cond_dep 'dev-python/configparser[${PYTHON_USEDEP}]' python2_7)
 	"
 RDEPEND="
 	dev-python/networkx[${PYTHON_USEDEP}]
@@ -35,6 +36,16 @@ RDEPEND="
 	sci-libs/scipy[${PYTHON_USEDEP}]
 	dev-python/simplejson[${PYTHON_USEDEP}]
 	"
+
+python_prepare_all() {
+	distutils-r1_python_prepare_all
+	EXISTING_REQUIRE="setup_requires=['future', 'configparser']"
+	CORRECTED_REQUIRE="setup_requires=['future']"
+	sed \
+		-e "s/${EXISTING_REQUIRE}/${CORRECTED_REQUIRE}/g" \
+		-i setup.py \
+		|| die "sed setup.py"
+}
 
 python_test() {
 	nosetests -v || die


### PR DESCRIPTION
Currently nipype-9999 (and likely future releases) won't build because setup.py requires configparser (independently of the python version for which nipype is being installed). 

As configparser is only a python-2* backport of built-in python-3* functionality, it isn't marked python-3* compatible in Portage, so it can't be fetched for python-3* installs.