### PR TITLE
sci-libs/nipype: missing dependency

### DIFF
--- a/sci-libs/nipype/nipype-9999.ebuild
+++ b/sci-libs/nipype/nipype-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -23,11 +23,12 @@ DEPEND="
 	dev-python/prov[${PYTHON_USEDEP}]
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
-	sci-libs/nibabel[${PYTHON_USEDEP}]
+	>=sci-libs/nibabel-2.0.1[${PYTHON_USEDEP}]
 	test? ( dev-python/mock[${PYTHON_USEDEP}] )
 	$(python_gen_cond_dep 'dev-python/configparser[${PYTHON_USEDEP}]' python2_7)
 	"
 RDEPEND="
+	>=dev-python/click-6.6[${PYTHON_USEDEP}]
 	dev-python/networkx[${PYTHON_USEDEP}]
 	dev-python/pydotplus[${PYTHON_USEDEP}]
 	dev-python/pygraphviz[${PYTHON_USEDEP}]


### PR DESCRIPTION
Package-Manager: Portage-2.3.3, Repoman-2.3.1