### PR TITLE
Intel liberation

### DIFF
--- a/eclass/numeric-int64-multibuild.eclass
+++ b/eclass/numeric-int64-multibuild.eclass
@@ -23,8 +23,6 @@ case ${EAPI:-0} in
 	*) die "EAPI=${EAPI} is not supported" ;;
 esac
 
-MULTILIB_COMPAT=( abi_x86_{32,64} )
-
 inherit alternatives-2 eutils fortran-2 multilib-build numeric toolchain-funcs
 
 IUSE="int64"

--- a/virtual/blacs/blacs-1.1-r1.ebuild
+++ b/virtual/blacs/blacs-1.1-r1.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit multilib-build
 

--- a/virtual/blas/blas-2.1-r5.ebuild
+++ b/virtual/blas/blas-2.1-r5.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit multilib-build multilib
 

--- a/virtual/blas/blas-3.6-r100.ebuild
+++ b/virtual/blas/blas-3.6-r100.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit multilib-build multilib
 

--- a/virtual/blas/blas-3.7-r100.ebuild
+++ b/virtual/blas/blas-3.7-r100.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=6
 
-MULTILIB_COMPAT=( abi_x86_{32,64} )
-
 inherit multilib-build multilib
 
 DESCRIPTION="Virtual for FORTRAN 77 BLAS implementation"

--- a/virtual/cblas/cblas-2.0-r4.ebuild
+++ b/virtual/cblas/cblas-2.0-r4.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit multilib-build
 

--- a/virtual/cblas/cblas-3.6-r100.ebuild
+++ b/virtual/cblas/cblas-3.6-r100.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit multilib-build
 

--- a/virtual/cblas/cblas-3.7-r100.ebuild
+++ b/virtual/cblas/cblas-3.7-r100.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=6
 
-MULTILIB_COMPAT=( abi_x86_{32,64} )
-
 inherit multilib-build
 
 DESCRIPTION="Virtual for BLAS C implementation"

--- a/virtual/lapack/lapack-3.6-r100.ebuild
+++ b/virtual/lapack/lapack-3.6-r100.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit multilib-build
 

--- a/virtual/lapack/lapack-3.7-r100.ebuild
+++ b/virtual/lapack/lapack-3.7-r100.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=6
 
-MULTILIB_COMPAT=( abi_x86_{32,64} )
-
 inherit multilib-build
 
 DESCRIPTION="Virtual for Linear Algebra Package FORTRAN 77 implementation"

--- a/virtual/lapacke/lapacke-3.6.ebuild
+++ b/virtual/lapacke/lapacke-3.6.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit multilib-build
 

--- a/virtual/scalapack/scalapack-2.0.2.ebuild
+++ b/virtual/scalapack/scalapack-2.0.2.ebuild
@@ -1,9 +1,7 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit multilib-build
 


### PR DESCRIPTION
The use of `MULTILIB_COMPAT=( abi_x86_{32,64} )` throughout the blas infrastructure in the overlay prevent any blas/lapack to be used on arch other than x86/amd64. This is perfectly justified for intel mkl and related eclass but not for something like lapack-reference. As per the `multilib-build` man page:

> Note that setting this variable effectively disables support for all other ABIs, including other architectures. For example, specifying abi_x86_{32,64} disables support for MIPS as well.


Since this is implemented as `REQUIRED_USE` restrictions, no amount of `**` in a keyword file will help. Only hacking the eclass and virtual ebuilds will help. You cannot even test the ebuild, it goes much further than signalling no one support the ebuild on other archs.

For the record, I currently have access to ppc64 hardware and have been using the overlay there after modification. And it is perfectly OK and sensible to use `numeric-int64-multibuild` eclass on such architecture. Nothing ground breaking as far as I am concerned.