### PR TITLE
sci-visualization/forge: Make forge use system glm and freetype, they…

### DIFF
--- a/sci-visualization/forge/forge-9999.ebuild
+++ b/sci-visualization/forge/forge-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -37,6 +37,8 @@ src_configure() {
 	local mycmakeargs=(
 	   -DBUILD_EXAMPLES="$(examples EXAMPLES)"
 	   -DUSE_SYSTEM_GLBINDING=ON
+	   -DUSE_SYSTEM_GLM=ON
+	   -DUSE_SYSTEM_FREETYPE=ON
 	   -DFG_INSTALL_CMAKE_DIR=/usr/$(get_libdir)/cmake/Forge
 	)
 	cmake-utils_src_configure


### PR DESCRIPTION
Freetype and glm are already in dependencies. Right now forge tries to download and build own versions, which causes sandbox violations.