### PR TITLE
sci-biology/nilearn: importing system joblib

### DIFF
--- a/sci-biology/nilearn/nilearn-0.2.6.ebuild
+++ b/sci-biology/nilearn/nilearn-0.2.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -26,6 +26,19 @@ RDEPEND="
 	sci-libs/scipy[${PYTHON_USEDEP}]
 	sci-libs/nibabel[${PYTHON_USEDEP}]
 	plot? ( dev-python/matplotlib[${PYTHON_USEDEP}] )"
+
+# upstream is reluctant to *not* depend on bundled scikits_learn:
+# https://github.com/nilearn/nilearn/pull/1398
+python_prepare_all() {
+	for f in nilearn/{*/*/,*/,}*.py; do
+		sed -r \
+			-e '/^from/s/(sklearn|\.|)\.externals\.joblib/joblib/' \
+			-e 's/from (sklearn|\.|)\.externals import/import/' \
+		-i $f || die
+	done
+
+	distutils-r1_python_prepare_all
+}
 
 python_test() {
 	echo "backend: Agg" > matplotlibrc

--- a/sci-biology/nilearn/nilearn-0.2.6.ebuild
+++ b/sci-biology/nilearn/nilearn-0.2.6.ebuild
@@ -30,6 +30,7 @@ RDEPEND="
 # upstream is reluctant to *not* depend on bundled scikits_learn:
 # https://github.com/nilearn/nilearn/pull/1398
 python_prepare_all() {
+	local f
 	for f in nilearn/{*/*/,*/,}*.py; do
 		sed -r \
 			-e '/^from/s/(sklearn|\.|)\.externals\.joblib/joblib/' \

--- a/sci-biology/nilearn/nilearn-9999.ebuild
+++ b/sci-biology/nilearn/nilearn-9999.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 # upstream is reluctant to *not* depend on bundled scikits_learn:
 # https://github.com/nilearn/nilearn/pull/1398
 python_prepare_all() {
+	local f
 	for f in nilearn/{*/*/,*/,}*.py; do
 		sed -r \
 			-e '/^from/s/(sklearn|\.|)\.externals\.joblib/joblib/' \

--- a/sci-biology/nilearn/nilearn-9999.ebuild
+++ b/sci-biology/nilearn/nilearn-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -27,6 +27,19 @@ RDEPEND="
 	sci-libs/scipy[${PYTHON_USEDEP}]
 	sci-libs/nibabel[${PYTHON_USEDEP}]
 	plot? ( dev-python/matplotlib[${PYTHON_USEDEP}] )"
+
+# upstream is reluctant to *not* depend on bundled scikits_learn:
+# https://github.com/nilearn/nilearn/pull/1398
+python_prepare_all() {
+	for f in nilearn/{*/*/,*/,}*.py; do
+		sed -r \
+			-e '/^from/s/(sklearn|\.|)\.externals\.joblib/joblib/' \
+			-e 's/from (sklearn|\.|)\.externals import/import/' \
+		-i $f || die
+	done
+
+	distutils-r1_python_prepare_all
+}
 
 python_test() {
 	echo "backend: Agg" > matplotlibrc


### PR DESCRIPTION
Upstream imports joblib **not** from joblib, but from a scikits_learn bundled version.
We unbundle skits_learn for obvious reasons, so we also have to patch this.

It appears that this strange configuration arises from nilearn and scikits_learn sharing one developer who really wants this to be bundled (he has not explained why). We might be able to address the bundling issue for both packages if we bring this up again/with better arguments/in a different context:

* [trying to get **nilearn** to unbundle](https://github.com/nilearn/nilearn/pull/1398).
* [trying to get **scikits_learn** to unbundle](https://github.com/scikit-learn/scikit-learn/issues/8494)