### PR TITLE
sci-visualization/surf-ice: added proper app data install paths

### DIFF
--- a/sci-visualization/surf-ice/surf-ice-1.0.20170202.ebuild
+++ b/sci-visualization/surf-ice/surf-ice-1.0.20170202.ebuild
@@ -33,7 +33,7 @@ src_install() {
 	doins shadersOld/*.txt
 
 	doicon -s scalable Surfice.jpg
-	make_desktop_entry surf-ice surf-ice /usr/share/icons/hicolor/scalable/apps/Surfice.jpg
+	make_desktop_entry surfice surfice /usr/share/icons/hicolor/scalable/apps/Surfice.jpg
 }
 
 pkg_postinst() {

--- a/sci-visualization/surf-ice/surf-ice-9999.ebuild
+++ b/sci-visualization/surf-ice/surf-ice-9999.ebuild
@@ -24,14 +24,11 @@ src_compile() {
 src_install() {
 	dobin surfice
 
-	insinto /usr/bin/shaders
-	doins shaders/*.txt
-
-	insinto /usr/bin/shadersOld
-	doins shadersOld/*.txt
+	insinto /usr/share/surfice
+	doins lut/* script/* shaders/* shadersOld/*
 
 	doicon -s scalable Surfice.jpg
-	make_desktop_entry surf-ice surf-ice /usr/share/icons/hicolor/scalable/apps/Surfice.jpg
+	make_desktop_entry surfice surfice /usr/share/icons/hicolor/scalable/apps/Surfice.jpg
 }
 
 pkg_postinst() {


### PR DESCRIPTION
and corrected executable name for GNOME launcher

Package-Manager: Portage-2.3.4, Repoman-2.3.2