### PR TITLE
sci-libs/nipype: updted dependencies

### DIFF
--- a/sci-libs/nipype/nipype-9999.ebuild
+++ b/sci-libs/nipype/nipype-9999.ebuild
@@ -24,7 +24,10 @@ DEPEND="
 	dev-python/numpy[${PYTHON_USEDEP}]
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	>=sci-libs/nibabel-2.0.1[${PYTHON_USEDEP}]
-	test? ( dev-python/mock[${PYTHON_USEDEP}] )
+	test? (
+		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+	)
 	$(python_gen_cond_dep 'dev-python/configparser[${PYTHON_USEDEP}]' python2_7)
 	"
 RDEPEND="
@@ -32,7 +35,8 @@ RDEPEND="
 	dev-python/networkx[${PYTHON_USEDEP}]
 	dev-python/pydotplus[${PYTHON_USEDEP}]
 	dev-python/pygraphviz[${PYTHON_USEDEP}]
-	dev-python/traits[${PYTHON_USEDEP}]
+	dev-python/pytest[${PYTHON_USEDEP}]
+	>=dev-python/traits-4.6.0[${PYTHON_USEDEP}]
 	sci-libs/scipy[${PYTHON_USEDEP}]
 	dev-python/simplejson[${PYTHON_USEDEP}]
 	"


### PR DESCRIPTION
upstream (as of now) still insists that pytest should be available at runtime
and explicitly checks

Package-Manager: Portage-2.3.5, Repoman-2.3.2